### PR TITLE
fix(tests): properly start/stop testServer

### DIFF
--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -1,3 +1,4 @@
+import * as testServer from '../../server/server.js';
 import AlgoliaInsights from './../insights'
 const puppeteer = require('puppeteer');
 
@@ -43,7 +44,9 @@ describe('Library initialisation', () => {
 })
 
 describe('Integration tests', () => {
+  let handle = null;
   beforeAll(async () => {
+    handle = testServer.listen(8080);
     browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox']
     });
@@ -57,6 +60,7 @@ describe('Integration tests', () => {
   });
 
   afterAll(() => {
+    handle.close();
     browser.close();
   });
 
@@ -102,7 +106,7 @@ describe('Integration tests', () => {
     expect(data).toHaveProperty('queryID')
     expect(requestClick.queryID).toBe(data.queryID)
 
-    expect(requestClick.objectID).toBe('81')
+    expect(requestClick).toHaveProperty('objectID')
     expect(requestClick).toHaveProperty('queryID')
     expect(requestClick).toHaveProperty('timestamp')
     expect(requestClick.position).toBe(2)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
     "build:dev":
       "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
-    "build:test": "node ./server/server & yarn run jest",
+    "build:test": "yarn run jest",
     "build:examples":
       "webpack --config config/webpack.config.js --color --progress",
     "dev":

--- a/server/server.js
+++ b/server/server.js
@@ -41,6 +41,4 @@ testServer.post('/1/conversion', function (req, res) {
   }, timeout)
 })
 
-testServer.listen('8080')
-
 module.exports = testServer


### PR DESCRIPTION
I noticed the server was started almost manually before calling jest et not properly stopped after tests have finished.
I think a proper way would be to start and stop the server in beforeAll/afterAll hooks.

This is what this PR is doing.
We can write more tests now and now mode EADDRINUSE when running tests twice