### PR TITLE
chore(examples): update to 0.0.16

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -8,7 +8,7 @@ const WebpackChunkHash = require('webpack-chunk-hash');
 
 const isProd = process.env.NODE_ENV === "production";
 const { NODE_ENV, APP_ID, API_KEY, INDEX_NAME } = process.env;
-const SCRIPT_SRC = NODE_ENV === 'production' ? 'https://cdn.jsdelivr.net/npm/search-insights@0.0.15/dist/search-insights.min.js' : 'http://localhost:8080/search-insights.min.js';
+const SCRIPT_SRC = NODE_ENV === 'production' ? 'https://cdn.jsdelivr.net/npm/search-insights@~0.0.16/dist/search-insights.min.js' : 'http://localhost:8080/search-insights.min.js';
 
 const replaceHTMLPlugin = new HtmlReplaceWebpackPlugin([
   {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -8,7 +8,7 @@ const WebpackChunkHash = require('webpack-chunk-hash');
 
 const isProd = process.env.NODE_ENV === "production";
 const { NODE_ENV, APP_ID, API_KEY, INDEX_NAME } = process.env;
-const SCRIPT_SRC = NODE_ENV === 'production' ? 'https://cdn.jsdelivr.net/npm/search-insights@~0.0.16/dist/search-insights.min.js' : 'http://localhost:8080/search-insights.min.js';
+const SCRIPT_SRC = NODE_ENV === 'production' ? 'https://cdn.jsdelivr.net/npm/search-insights@0.0.16/dist/search-insights.min.js' : 'http://localhost:8080/search-insights.min.js';
 
 const replaceHTMLPlugin = new HtmlReplaceWebpackPlugin([
   {


### PR DESCRIPTION
Just released 0.0.16.
When NODE_ENV=production examples are compiled to use a specific version on the CDN.

This PR updates the examples to use `~0.0.16`.
I would have used `^0.0.16` but oddly enough the CDN does not return `0.0.16` in that case