### PR TITLE
feat(click): introduce generic click method clickedObjectID and clickedFilters

### DIFF
--- a/examples/async/async.js
+++ b/examples/async/async.js
@@ -176,7 +176,7 @@ search.start();
 
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    aa("click", {
+    aa("clickedObjectIDInSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/helper/helper.js
+++ b/examples/helper/helper.js
@@ -24,7 +24,7 @@ helper.on("result", function(content) {
 const hit = (hit, index) => {
   return `
     <div className="col-3">${hit.name}
-      <button onclick="aa('click',{objectIDs: [${
+      <button onclick="aa('clickedObjectIDInSearch',{objectIDs: [${
         hit.objectID
       }], positions: [${index + 1}]})">Click</button>
       <button onclick="aa('conversion',{objectIDs: [${

--- a/examples/instantsearch/instantsearchExample.js
+++ b/examples/instantsearch/instantsearchExample.js
@@ -177,7 +177,7 @@ search.start();
 
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    window.aa("click", {
+    window.aa("clickedObjectIDInSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/lunr/lunr.js
+++ b/examples/lunr/lunr.js
@@ -84,7 +84,7 @@ window.aa("init", {
 // Analytics
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    window.aa("click", {
+    window.aa("clickedObjectIDInSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       objectIDs: [e.target.getAttribute("objectid")],

--- a/examples/react-instantsearch/src/App.js
+++ b/examples/react-instantsearch/src/App.js
@@ -28,7 +28,7 @@ const Hits = connectHits(
           <Highlight attributeName="name" hit={hit} />
           <button
             onClick={() => {
-              window.aa('click', {
+              window.aa('clickedObjectIDInSearch', {
                 eventName: "hit-clicked",
                 index: process.env.INDEX_NAME,
                 queryID: searchResults.queryID,

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -5,20 +5,23 @@ const credentials = {
   applicationID: "test"
 };
 
-describe("Click method", () => {
+describe("clickedObjectIDInSearch", () => {
   test("Should throw if queryID, objectIDs or positions are not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.click();
+      AlgoliaInsights.clickedObjectIDInSearch();
     }).toThrowError(
-      "No params were sent to click function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
+      "No params were sent to clickedObjectIDInSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
     );
   });
 
   test("Should throw if objectIDs is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.click({ queryID: "testing", positions: [1] });
+      (AlgoliaInsights as any).clickedObjectIDInSearch({
+        queryID: "testing",
+        positions: [1]
+      });
     }).toThrowError(
       "required objectIDs parameter was not sent, click event can not be properly sent without"
     );
@@ -27,7 +30,10 @@ describe("Click method", () => {
   test("Should throw if positions is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.click({ queryID: "testing", objectIDs: [1] });
+      (AlgoliaInsights as any).clickedObjectIDInSearch({
+        queryID: "testing",
+        objectIDs: [1]
+      });
     }).toThrowError(
       "required positions parameter was not sent, click event can not be properly sent without"
     );
@@ -36,7 +42,10 @@ describe("Click method", () => {
   test("Should throw if queryID is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.click({ objectIDs: ["1"], positions: [1] });
+      (AlgoliaInsights as any).clickedObjectIDInSearch({
+        objectIDs: ["1"],
+        positions: [1]
+      });
     }).toThrowError(
       "required queryID parameter was not sent, click event can not be properly sent without"
     );
@@ -51,7 +60,73 @@ describe("Click method", () => {
 
     AlgoliaInsights.init(credentials);
     (AlgoliaInsights as any).sendEvent = jest.fn();
-    AlgoliaInsights.click(clickParams);
+    AlgoliaInsights.clickedObjectIDInSearch(clickParams);
+
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
+      "click",
+      clickParams
+    );
+  });
+});
+
+describe("clickedObjectID", () => {
+  it("should throw if no parameters is passed", () => {
+    AlgoliaInsights.init(credentials);
+    expect(() => {
+      AlgoliaInsights.clickedObjectID();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"No params were sent to clickedObjectID function, please provide \`objectIDs\` to be reported"`
+    );
+  });
+  it("should throw if objectIDs is not sent", () => {
+    AlgoliaInsights.init(credentials);
+    expect(() => {
+      AlgoliaInsights.clickedObjectID({});
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"required \`objectIDs\` parameter was not sent, click event can not be properly sent without"`
+    );
+  });
+  it("should call sendEvent with proper params", () => {
+    const clickParams = {
+      objectIDs: ["2"]
+    };
+
+    AlgoliaInsights.init(credentials);
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.clickedObjectID(clickParams);
+
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
+      "click",
+      clickParams
+    );
+  });
+});
+
+describe("clickedFilters", () => {
+  it("should throw if no parameters is passed", () => {
+    AlgoliaInsights.init(credentials);
+    expect(() => {
+      AlgoliaInsights.clickedFilters();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"No params were sent to clickedFilters function, please provide \`filters\` to be reported"`
+    );
+  });
+  it("should throw if filters is not sent", () => {
+    AlgoliaInsights.init(credentials);
+    expect(() => {
+      AlgoliaInsights.clickedFilters({});
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"required \`filters\` parameter was not sent, click event can not be properly sent without"`
+    );
+  });
+  it("should call sendEvent with proper params", () => {
+    const clickParams = {
+      filters: ["brands:apple"]
+    };
+
+    AlgoliaInsights.init(credentials);
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.clickedFilters(clickParams);
 
     expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
       "click",

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,3 +1,5 @@
+import { InsightsEvent } from "./_sendEvent";
+
 export interface InsightsSearchClickEvent {
   eventName: string;
   userID: string;
@@ -10,18 +12,13 @@ export interface InsightsSearchClickEvent {
 }
 
 /**
- * Sends a click report
+ * Sends a click report in the context of search
  * @param params: InsightsSearchClickEvent
  */
-export function click(params: InsightsSearchClickEvent) {
-  if (!this._hasCredentials) {
-    throw new Error(
-      "Before calling any methods on the analytics, you first need to call the 'init' function with applicationID and apiKey parameters"
-    );
-  }
+export function clickedObjectIDInSearch(params: InsightsSearchClickEvent) {
   if (!params) {
     throw new Error(
-      "No params were sent to click function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
+      "No params were sent to clickedObjectIDInSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
     );
   }
   if (!params.queryID) {
@@ -40,6 +37,61 @@ export function click(params: InsightsSearchClickEvent) {
     );
   }
 
-  // Send event
-  this.sendEvent("click", params);
+  this.sendEvent("click", params as InsightsEvent);
+}
+
+export interface InsightsClickObjectIDsEvent {
+  eventName: string;
+  userID: string;
+  timestamp: number;
+  index: string;
+
+  objectIDs: (string | number)[];
+}
+
+/**
+ * Sends a click report using objectIDs
+ * @param params: InsightsClickObjectIDsEvent
+ */
+export function clickedObjectID(params: InsightsClickObjectIDsEvent) {
+  if (!params) {
+    throw new Error(
+      "No params were sent to clickedObjectID function, please provide `objectIDs` to be reported"
+    );
+  }
+  if (!params.objectIDs) {
+    throw new Error(
+      "required `objectIDs` parameter was not sent, click event can not be properly sent without"
+    );
+  }
+
+  this.sendEvent("click", params as InsightsEvent);
+}
+
+export interface InsightsClickFiltersEvent {
+  eventName: string;
+  userID: string;
+  timestamp: number;
+  index: string;
+
+  filters: string[];
+}
+
+/**
+ * Sends a click report using filters
+ * @param params: InsightsClickFiltersEvent
+ */
+export function clickedFilters(params: InsightsClickFiltersEvent) {
+  if (!params) {
+    throw new Error(
+      "No params were sent to clickedFilters function, please provide `filters` to be reported"
+    );
+  }
+  if (!params.filters) {
+    throw new Error(
+      "required `filters` parameter was not sent, click event can not be properly sent without"
+    );
+  }
+
+  this.sendEvent("click", params as InsightsEvent);
 }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -5,13 +5,20 @@ objectKeysPolyfill();
 objectAssignPolyfill();
 
 import { processQueue } from "./_processQueue";
-import { sendEvent, InsightsEventType } from "./_sendEvent";
+import { sendEvent, InsightsEventType, InsightsEvent } from "./_sendEvent";
 import { StorageManager } from "./_storageManager";
 import { userID } from "./_cookieUtils";
 
 import { InitParams, init } from "./init";
 import { initSearch, InitSearchParams } from "./_initSearch";
-import { InsightsSearchClickEvent, click } from "./click";
+import {
+  InsightsSearchClickEvent,
+  clickedObjectIDInSearch,
+  clickedObjectID,
+  clickedFilters,
+  InsightsClickFiltersEvent,
+  InsightsClickObjectIDsEvent
+} from "./click";
 import { InsightsSearchConversionEvent, conversion } from "./conversion";
 
 type Queue = {
@@ -45,14 +52,16 @@ class AlgoliaAnalytics {
   private processQueue: () => void;
   private sendEvent: (
     eventType: InsightsEventType,
-    data: InsightsSearchClickEvent | InsightsSearchConversionEvent
+    data: InsightsEvent
   ) => void;
   private _hasCredentials: boolean = false;
 
   // Public methods
   public init: (params: InitParams) => void;
   public initSearch: (params: InitSearchParams) => void;
-  public click: (params?: Partial<InsightsSearchClickEvent>) => void;
+  public clickedObjectIDInSearch: (params?: InsightsSearchClickEvent) => void;
+  public clickedObjectID: (params?: InsightsClickObjectIDsEvent) => void;
+  public clickedFilters: (params?: InsightsClickFiltersEvent) => void;
   public conversion: (params?: Partial<InsightsSearchConversionEvent>) => void;
 
   constructor(options?: any) {
@@ -73,7 +82,11 @@ class AlgoliaAnalytics {
     // Bind public methods to `this` class
     this.init = init.bind(this);
     this.initSearch = initSearch.bind(this);
-    this.click = click.bind(this);
+
+    this.clickedObjectIDInSearch = clickedObjectIDInSearch.bind(this);
+    this.clickedObjectID = clickedObjectID.bind(this);
+    this.clickedFilters = clickedFilters.bind(this);
+
     this.conversion = conversion.bind(this);
 
     this._userID = userID();


### PR DESCRIPTION
This PR adds report methods for click: `clickedObjectIDInSearch`, `clickedObjectID`, `clickedFilters`.


- migrated `click` => `clickedObjectIDInSearch` (code + examples that use it)
- created clickedObjectID and clickedFilters
