### PR TITLE
feat(conversion): migrate conversion to convertedObjectIDInSearch

### DIFF
--- a/examples/async/async.js
+++ b/examples/async/async.js
@@ -184,7 +184,7 @@ document.addEventListener("click", e => {
       positions: [parseInt(e.target.getAttribute("data-position"))]
     });
   } else if (e.target.matches(".button-convert")) {
-    aa("conversion", {
+    aa("convertedObjectIDInSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/instantsearch/instantsearchExample.js
+++ b/examples/instantsearch/instantsearchExample.js
@@ -185,7 +185,7 @@ document.addEventListener("click", e => {
       positions: [parseInt(e.target.getAttribute("data-position"))]
     });
   } else if (e.target.matches(".button-convert")) {
-    window.aa("conversion", {
+    window.aa("convertedObjectIDInSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/lunr/lunr.js
+++ b/examples/lunr/lunr.js
@@ -91,7 +91,7 @@ document.addEventListener("click", e => {
       positions: [e.target.getAttribute("position")]
     });
   } else if (e.target.matches(".button-convert")) {
-    window.aa("conversion", {
+    window.aa("convertedObjectIDInSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       objectIDs: [e.target.getAttribute("objectid")]

--- a/examples/react-instantsearch/src/App.js
+++ b/examples/react-instantsearch/src/App.js
@@ -42,7 +42,7 @@ const Hits = connectHits(
           </button>
           <button
             onClick={() => {
-              window.aa('conversion', {
+              window.aa('convertedObjectIDInSearch', {
                 eventName: "hit-converted",
                 index: process.env.INDEX_NAME,
                 queryID: searchResults.queryID,

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -4,47 +4,53 @@ const credentials = {
   apiKey: "test",
   applicationID: "test"
 };
+describe("convertedObjectIDInSearch", () => {
+  it("Should throw if no params are sent", () => {
+    expect(() => {
+      AlgoliaInsights.init(credentials);
+      (AlgoliaInsights as any).convertedObjectIDInSearch();
+    }).toThrowError(
+      "No params were sent to convertedObjectIDInSearch function, please provide `queryID` and `objectIDs` to be reported"
+    );
+  });
 
-it("Should throw if no params are sent", () => {
-  expect(() => {
+  it("Should throw if no queryID has been passed", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
     AlgoliaInsights.init(credentials);
-    AlgoliaInsights.conversion();
-  }).toThrowError(
-    "No params were sent to conversion function, please provide `queryID` and `objectIDs` to be reported"
-  );
-});
 
-it("Should throw if no queryID has been passed", () => {
-  (AlgoliaInsights as any).sendEvent = jest.fn();
-  AlgoliaInsights.init(credentials);
+    expect(() => {
+      (AlgoliaInsights as any).convertedObjectIDInSearch({
+        objectIDs: ["12345"]
+      });
+      expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
+    }).toThrowError(
+      "required queryID parameter was not sent, conversion event can not be properly sent without"
+    );
+  });
 
-  expect(() => {
-    AlgoliaInsights.conversion({ objectIDs: ["12345"] });
-    expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
-  }).toThrowError(
-    "required queryID parameter was not sent, conversion event can not be properly sent without"
-  );
-});
+  it("Should throw if no objectIDs has been passed", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
 
-it("Should throw if no objectIDs has been passed", () => {
-  (AlgoliaInsights as any).sendEvent = jest.fn();
-  AlgoliaInsights.init(credentials);
+    expect(() => {
+      (AlgoliaInsights as any).convertedObjectIDInSearch({ queryID: "test" });
+      expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
+    }).toThrowError(
+      "required objectIDs parameter was not sent, conversion event can not be properly sent without"
+    );
+  });
 
-  expect(() => {
-    AlgoliaInsights.conversion({ queryID: "test" });
-    expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
-  }).toThrowError(
-    "required objectIDs parameter was not sent, conversion event can not be properly sent without"
-  );
-});
-
-it("Should send allow passing of queryID", () => {
-  (AlgoliaInsights as any).sendEvent = jest.fn();
-  AlgoliaInsights.init(credentials);
-  AlgoliaInsights.conversion({ objectIDs: ["12345"], queryID: "test" });
-  expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalled();
-  expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
-    "conversion",
-    { objectIDs: ["12345"], queryID: "test" }
-  );
+  it("Should send allow passing of queryID", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
+    AlgoliaInsights.convertedObjectIDInSearch({
+      objectIDs: ["12345"],
+      queryID: "test"
+    });
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalled();
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
+      "conversion",
+      { objectIDs: ["12345"], queryID: "test" }
+    );
+  });
 });

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,3 +1,5 @@
+import { InsightsEvent } from "./_sendEvent";
+
 export interface InsightsSearchConversionEvent {
   eventName: string;
   userID: string;
@@ -9,13 +11,15 @@ export interface InsightsSearchConversionEvent {
 }
 
 /**
- * Checks params for conversion report and sends query
+ * Sends a conversion report in the context of search
  * @param params InsightsSearchConversionEvent
  */
-export function conversion(params: InsightsSearchConversionEvent) {
+export function convertedObjectIDInSearch(
+  params: InsightsSearchConversionEvent
+) {
   if (!params) {
     throw new Error(
-      "No params were sent to conversion function, please provide `queryID` and `objectIDs` to be reported"
+      "No params were sent to convertedObjectIDInSearch function, please provide `queryID` and `objectIDs` to be reported"
     );
   }
   if (!params.queryID) {
@@ -29,6 +33,5 @@ export function conversion(params: InsightsSearchConversionEvent) {
     );
   }
 
-  // Send event
-  this.sendEvent("conversion", params);
+  this.sendEvent("conversion", params as InsightsEvent);
 }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -19,7 +19,10 @@ import {
   InsightsClickFiltersEvent,
   InsightsClickObjectIDsEvent
 } from "./click";
-import { InsightsSearchConversionEvent, conversion } from "./conversion";
+import {
+  InsightsSearchConversionEvent,
+  convertedObjectIDInSearch
+} from "./conversion";
 
 type Queue = {
   queue: string[][];
@@ -62,7 +65,9 @@ class AlgoliaAnalytics {
   public clickedObjectIDInSearch: (params?: InsightsSearchClickEvent) => void;
   public clickedObjectID: (params?: InsightsClickObjectIDsEvent) => void;
   public clickedFilters: (params?: InsightsClickFiltersEvent) => void;
-  public conversion: (params?: Partial<InsightsSearchConversionEvent>) => void;
+  public convertedObjectIDInSearch: (
+    params?: InsightsSearchConversionEvent
+  ) => void;
 
   constructor(options?: any) {
     // Exit on old browsers or if script is not ran in browser
@@ -87,7 +92,7 @@ class AlgoliaAnalytics {
     this.clickedObjectID = clickedObjectID.bind(this);
     this.clickedFilters = clickedFilters.bind(this);
 
-    this.conversion = conversion.bind(this);
+    this.convertedObjectIDInSearch = convertedObjectIDInSearch.bind(this);
 
     this._userID = userID();
 


### PR DESCRIPTION
This PR replaces the old method `conversion` with `convertedObjectIDInSearch`.
adding `convertedObjectID` and `convertedFilters`