### PR TITLE
feat(view): add viewedObjectIDs and viewedFilters

### DIFF
--- a/lib/__tests__/view.test.ts
+++ b/lib/__tests__/view.test.ts
@@ -1,0 +1,74 @@
+import AlgoliaInsights from "../insights";
+
+const credentials = {
+  apiKey: "test",
+  applicationID: "test"
+};
+describe("viewedObjectIDs", () => {
+  it("should throw if no params are sent", () => {
+    expect(() => {
+      AlgoliaInsights.init(credentials);
+      (AlgoliaInsights as any).viewedObjectIDs();
+    }).toThrowError(
+      "No params were sent to viewedObjectIDs function, please provide `objectIDs` to be reported"
+    );
+  });
+
+  it("should throw if no objectIDs has been passed", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
+
+    expect(() => {
+      (AlgoliaInsights as any).viewedObjectIDs({ queryID: "test" });
+      expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
+    }).toThrowError(
+      "required objectIDs parameter was not sent, view event can not be properly sent without"
+    );
+  });
+
+  it("should send allow passing of queryID", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
+    AlgoliaInsights.viewedObjectIDs({
+      objectIDs: ["12345"]
+    });
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalled();
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith("view", {
+      objectIDs: ["12345"]
+    });
+  });
+});
+describe("viewedFilters", () => {
+  it("should throw if no params are sent", () => {
+    expect(() => {
+      AlgoliaInsights.init(credentials);
+      (AlgoliaInsights as any).viewedFilters();
+    }).toThrowError(
+      "No params were sent to viewedFilters function, please provide `filters` to be reported"
+    );
+  });
+
+  it("should throw if no objectIDs has been passed", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
+
+    expect(() => {
+      (AlgoliaInsights as any).viewedFilters({});
+      expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
+    }).toThrowError(
+      "required filters parameter was not sent, view event can not be properly sent without"
+    );
+  });
+
+  it("should send allow passing of queryID", () => {
+    (AlgoliaInsights as any).sendEvent = jest.fn();
+    AlgoliaInsights.init(credentials);
+    AlgoliaInsights.viewedFilters({
+      filters: ["brands:apple"]
+    });
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalled();
+    expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith("view", {
+      filters: ["brands:apple"]
+    });
+  });
+});

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -27,6 +27,12 @@ import {
   InsightsSearchConversionFiltersEvent,
   convertedFilters
 } from "./conversion";
+import {
+  InsightsSearchViewObjectIDsEvent,
+  viewedObjectIDs,
+  InsightsSearchViewFiltersEvent,
+  viewedFilters
+} from "./view";
 
 type Queue = {
   queue: string[][];
@@ -72,8 +78,15 @@ class AlgoliaAnalytics {
   public convertedObjectIDInSearch: (
     params?: InsightsSearchConversionEvent
   ) => void;
-  public convertedObjectIDs: (params?: InsightsSearchConversionObjectIDsEvent) => void;
-  public convertedFilters: (params?: InsightsSearchConversionFiltersEvent) => void;
+  public convertedObjectIDs: (
+    params?: InsightsSearchConversionObjectIDsEvent
+  ) => void;
+  public convertedFilters: (
+    params?: InsightsSearchConversionFiltersEvent
+  ) => void;
+
+  public viewedObjectIDs: (params?: InsightsSearchViewObjectIDsEvent) => void;
+  public viewedFilters: (params?: InsightsSearchViewFiltersEvent) => void;
 
   constructor(options?: any) {
     // Exit on old browsers or if script is not ran in browser
@@ -101,6 +114,9 @@ class AlgoliaAnalytics {
     this.convertedObjectIDInSearch = convertedObjectIDInSearch.bind(this);
     this.convertedObjectIDs = convertedObjectIDs.bind(this);
     this.convertedFilters = convertedFilters.bind(this);
+
+    this.viewedObjectIDs = viewedObjectIDs.bind(this);
+    this.viewedFilters = viewedFilters.bind(this);
 
     this._userID = userID();
 

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -1,0 +1,55 @@
+import { InsightsEvent } from "./_sendEvent";
+
+export interface InsightsSearchViewObjectIDsEvent {
+  eventName: string;
+  userID: string;
+  timestamp: number;
+  index: string;
+
+  objectIDs: (string | number)[];
+}
+/**
+ * Sends a view report using objectIDs
+ * @param params InsightsSearchViewObjectIDsEvent
+ */
+export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
+  if (!params) {
+    throw new Error(
+      "No params were sent to viewedObjectIDs function, please provide `objectIDs` to be reported"
+    );
+  }
+  if (!params.objectIDs) {
+    throw new Error(
+      "required objectIDs parameter was not sent, view event can not be properly sent without"
+    );
+  }
+
+  this.sendEvent("view", params as InsightsEvent);
+}
+
+export interface InsightsSearchViewFiltersEvent {
+  eventName: string;
+  userID: string;
+  timestamp: number;
+  index: string;
+
+  filters: string[];
+}
+/**
+ * Sends a view report using filters
+ * @param params InsightsSearchViewFiltersEvent
+ */
+export function viewedFilters(params: InsightsSearchViewFiltersEvent) {
+  if (!params) {
+    throw new Error(
+      "No params were sent to viewedFilters function, please provide `filters` to be reported"
+    );
+  }
+  if (!params.filters) {
+    throw new Error(
+      "required filters parameter was not sent, view event can not be properly sent without"
+    );
+  }
+
+  this.sendEvent("view", params as InsightsEvent);
+}


### PR DESCRIPTION
This PR adds generic methods `viewedObjectIDs` and `viewedFilters` as specified in the related [RFC](https://github.com/algolia/instantsearch-rfcs/blob/feat/search-insights-client/accepted/search-insights-client.md#detailed-design-by-stories)