### PR TITLE
feat(region): use region based endpoint

### DIFF
--- a/examples/async/async.js
+++ b/examples/async/async.js
@@ -176,7 +176,7 @@ search.start();
 
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    aa("clickedObjectIDInSearch", {
+    aa("clickedObjectIDsAfterSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),
@@ -184,7 +184,7 @@ document.addEventListener("click", e => {
       positions: [parseInt(e.target.getAttribute("data-position"))]
     });
   } else if (e.target.matches(".button-convert")) {
-    aa("convertedObjectIDInSearch", {
+    aa("convertedObjectIDsAfterSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/helper/helper.js
+++ b/examples/helper/helper.js
@@ -24,7 +24,7 @@ helper.on("result", function(content) {
 const hit = (hit, index) => {
   return `
     <div className="col-3">${hit.name}
-      <button onclick="aa('clickedObjectIDInSearch',{objectIDs: [${
+      <button onclick="aa('clickedObjectIDsAfterSearch',{objectIDs: [${
         hit.objectID
       }], positions: [${index + 1}]})">Click</button>
       <button onclick="aa('conversion',{objectIDs: [${

--- a/examples/instantsearch/instantsearchExample.js
+++ b/examples/instantsearch/instantsearchExample.js
@@ -177,7 +177,7 @@ search.start();
 
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    window.aa("clickedObjectIDInSearch", {
+    window.aa("clickedObjectIDsAfterSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),
@@ -185,7 +185,7 @@ document.addEventListener("click", e => {
       positions: [parseInt(e.target.getAttribute("data-position"))]
     });
   } else if (e.target.matches(".button-convert")) {
-    window.aa("convertedObjectIDInSearch", {
+    window.aa("convertedObjectIDsAfterSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       queryID: e.target.getAttribute("data-query-id"),

--- a/examples/lunr/lunr.js
+++ b/examples/lunr/lunr.js
@@ -84,14 +84,14 @@ window.aa("init", {
 // Analytics
 document.addEventListener("click", e => {
   if (e.target.matches(".button-click")) {
-    window.aa("clickedObjectIDInSearch", {
+    window.aa("clickedObjectIDsAfterSearch", {
       eventName: "hit-clicked",
       index: process.env.INDEX_NAME,
       objectIDs: [e.target.getAttribute("objectid")],
       positions: [e.target.getAttribute("position")]
     });
   } else if (e.target.matches(".button-convert")) {
-    window.aa("convertedObjectIDInSearch", {
+    window.aa("convertedObjectIDsAfterSearch", {
       eventName: "hit-converted",
       index: process.env.INDEX_NAME,
       objectIDs: [e.target.getAttribute("objectid")]

--- a/examples/react-instantsearch/src/App.js
+++ b/examples/react-instantsearch/src/App.js
@@ -28,7 +28,7 @@ const Hits = connectHits(
           <Highlight attributeName="name" hit={hit} />
           <button
             onClick={() => {
-              window.aa('clickedObjectIDInSearch', {
+              window.aa('clickedObjectIDsAfterSearch', {
                 eventName: "hit-clicked",
                 index: process.env.INDEX_NAME,
                 queryID: searchResults.queryID,
@@ -42,7 +42,7 @@ const Hits = connectHits(
           </button>
           <button
             onClick={() => {
-              window.aa('convertedObjectIDInSearch', {
+              window.aa('convertedObjectIDsAfterSearch', {
                 eventName: "hit-converted",
                 index: process.env.INDEX_NAME,
                 queryID: searchResults.queryID,

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -2,7 +2,7 @@ import AlgoliaInsights from "../insights";
 import * as url from "url";
 
 jest.mock("../_cookieUtils", () => ({
-  userID: jest.fn(() => "mock-user-id")
+  userToken: jest.fn(() => "mock-user-id")
 }));
 
 const credentials = {
@@ -113,6 +113,15 @@ describe("sendEvent", () => {
       }).toThrowError(
         "Before calling any methods on the analytics, you first need to call the 'init' function with applicationID and apiKey parameters"
       );
+    });
+    it("should do nothing is _userHasOptedOut === true", () => {
+      AlgoliaInsights._userHasOptedOut = true;
+      AlgoliaInsights.sendEvent("click", {
+        eventName: "my-event",
+        index: "my-index",
+        objectIDs: ["1"]
+      });
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -240,8 +249,8 @@ describe("sendEvent", () => {
     });
   });
 
-  describe("userID", () => {
-    it("should add a userID if not provided", () => {
+  describe("userToken", () => {
+    it("should add a userToken if not provided", () => {
       (AlgoliaInsights as any).sendEvent("click", {
         eventName: "my-event",
         index: "my-index",
@@ -252,24 +261,24 @@ describe("sendEvent", () => {
       expect(payload).toEqual({
         events: [
           expect.objectContaining({
-            userID: "mock-user-id"
+            userToken: "mock-user-id"
           })
         ]
       });
     });
-    it("should pass over provided userID", () => {
+    it("should pass over provided userToken", () => {
       (AlgoliaInsights as any).sendEvent("click", {
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"],
-        userID: "007"
+        userToken: "007"
       });
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
         events: [
           expect.objectContaining({
-            userID: "007"
+            userToken: "007"
           })
         ]
       });

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -5,20 +5,20 @@ const credentials = {
   applicationID: "test"
 };
 
-describe("clickedObjectIDInSearch", () => {
+describe("clickedObjectIDsAfterSearch", () => {
   test("Should throw if queryID, objectIDs or positions are not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.clickedObjectIDInSearch();
+      AlgoliaInsights.clickedObjectIDsAfterSearch();
     }).toThrowError(
-      "No params were sent to clickedObjectIDInSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
+      "No params were sent to clickedObjectIDsAfterSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
     );
   });
 
   test("Should throw if objectIDs is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      (AlgoliaInsights as any).clickedObjectIDInSearch({
+      (AlgoliaInsights as any).clickedObjectIDsAfterSearch({
         queryID: "testing",
         positions: [1]
       });
@@ -30,7 +30,7 @@ describe("clickedObjectIDInSearch", () => {
   test("Should throw if positions is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      (AlgoliaInsights as any).clickedObjectIDInSearch({
+      (AlgoliaInsights as any).clickedObjectIDsAfterSearch({
         queryID: "testing",
         objectIDs: [1]
       });
@@ -42,7 +42,7 @@ describe("clickedObjectIDInSearch", () => {
   test("Should throw if queryID is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      (AlgoliaInsights as any).clickedObjectIDInSearch({
+      (AlgoliaInsights as any).clickedObjectIDsAfterSearch({
         objectIDs: ["1"],
         positions: [1]
       });
@@ -60,7 +60,7 @@ describe("clickedObjectIDInSearch", () => {
 
     AlgoliaInsights.init(credentials);
     (AlgoliaInsights as any).sendEvent = jest.fn();
-    AlgoliaInsights.clickedObjectIDInSearch(clickParams);
+    AlgoliaInsights.clickedObjectIDsAfterSearch(clickParams);
 
     expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
       "click",
@@ -69,19 +69,19 @@ describe("clickedObjectIDInSearch", () => {
   });
 });
 
-describe("clickedObjectID", () => {
+describe("clickedObjectIDs", () => {
   it("should throw if no parameters is passed", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.clickedObjectID();
+      AlgoliaInsights.clickedObjectIDs();
     }).toThrowErrorMatchingInlineSnapshot(
-      `"No params were sent to clickedObjectID function, please provide \`objectIDs\` to be reported"`
+      `"No params were sent to clickedObjectIDs function, please provide \`objectIDs\` to be reported"`
     );
   });
   it("should throw if objectIDs is not sent", () => {
     AlgoliaInsights.init(credentials);
     expect(() => {
-      AlgoliaInsights.clickedObjectID({});
+      AlgoliaInsights.clickedObjectIDs({});
     }).toThrowErrorMatchingInlineSnapshot(
       `"required \`objectIDs\` parameter was not sent, click event can not be properly sent without"`
     );
@@ -93,7 +93,7 @@ describe("clickedObjectID", () => {
 
     AlgoliaInsights.init(credentials);
     (AlgoliaInsights as any).sendEvent = jest.fn();
-    AlgoliaInsights.clickedObjectID(clickParams);
+    AlgoliaInsights.clickedObjectIDs(clickParams);
 
     expect((AlgoliaInsights as any).sendEvent).toHaveBeenCalledWith(
       "click",

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -4,13 +4,13 @@ const credentials = {
   apiKey: "test",
   applicationID: "test"
 };
-describe("convertedObjectIDInSearch", () => {
+describe("convertedObjectIDsAfterSearch", () => {
   it("Should throw if no params are sent", () => {
     expect(() => {
       AlgoliaInsights.init(credentials);
-      (AlgoliaInsights as any).convertedObjectIDInSearch();
+      (AlgoliaInsights as any).convertedObjectIDsAfterSearch();
     }).toThrowError(
-      "No params were sent to convertedObjectIDInSearch function, please provide `queryID` and `objectIDs` to be reported"
+      "No params were sent to convertedObjectIDsAfterSearch function, please provide `queryID` and `objectIDs` to be reported"
     );
   });
 
@@ -19,7 +19,7 @@ describe("convertedObjectIDInSearch", () => {
     AlgoliaInsights.init(credentials);
 
     expect(() => {
-      (AlgoliaInsights as any).convertedObjectIDInSearch({
+      (AlgoliaInsights as any).convertedObjectIDsAfterSearch({
         objectIDs: ["12345"]
       });
       expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
@@ -33,7 +33,9 @@ describe("convertedObjectIDInSearch", () => {
     AlgoliaInsights.init(credentials);
 
     expect(() => {
-      (AlgoliaInsights as any).convertedObjectIDInSearch({ queryID: "test" });
+      (AlgoliaInsights as any).convertedObjectIDsAfterSearch({
+        queryID: "test"
+      });
       expect((AlgoliaInsights as any).sendEvent).not.toHaveBeenCalled();
     }).toThrowError(
       "required objectIDs parameter was not sent, conversion event can not be properly sent without"
@@ -43,7 +45,7 @@ describe("convertedObjectIDInSearch", () => {
   it("Should send allow passing of queryID", () => {
     (AlgoliaInsights as any).sendEvent = jest.fn();
     AlgoliaInsights.init(credentials);
-    AlgoliaInsights.convertedObjectIDInSearch({
+    AlgoliaInsights.convertedObjectIDsAfterSearch({
       objectIDs: ["12345"],
       queryID: "test"
     });

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -53,7 +53,7 @@ describe("Library initialisation", () => {
   });
 
   it("Should create UUID", () => {
-    expect(AlgoliaInsights._userID).not.toBeUndefined();
+    expect(AlgoliaInsights._userToken).not.toBeUndefined();
   });
 });
 

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -122,6 +122,9 @@ describe("Integration tests", () => {
       let payload;
       let objectIDs;
       beforeAll(async () => {
+        await page.evaluate(() => {
+          window.AlgoliaAnalytics._endpointOrigin = "http://localhost:8080";
+        });
         const event = await captureNetworkWhile(async () => {
           const button = await page.$(
             ".ais-hits--item:nth-child(2) .button-click"

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -50,6 +50,18 @@ describe("init", () => {
     AlgoliaInsights.init({ apiKey: "***", applicationID: "XXX", region: "us" });
     expect(AlgoliaInsights._region).toBe("us");
   });
+  it("should set _userHasOptedOut on instance to false by default", () => {
+    AlgoliaInsights.init({ apiKey: "***", applicationID: "XXX" });
+    expect(AlgoliaInsights._userHasOptedOut).toBe(false);
+  });
+  it("should set _userHasOptedOut on instance when passed", () => {
+    AlgoliaInsights.init({
+      apiKey: "***",
+      applicationID: "XXX",
+      userHasOptedOut: true
+    });
+    expect(AlgoliaInsights._userHasOptedOut).toBe(true);
+  });
   it("should set _endpointOrigin on instance to https://insights.algolia.io", () => {
     AlgoliaInsights.init({ apiKey: "***", applicationID: "XXX" });
     expect(AlgoliaInsights._endpointOrigin).toBe("https://insights.algolia.io");

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -40,15 +40,15 @@ const getCookie = (cname: string): string => {
  * @return {[string]} new UUID
  */
 const checkUserIdCookie = (userSpecifiedID?: string | number): string => {
-  const userID = getCookie(COOKIE_KEY);
+  const userToken = getCookie(COOKIE_KEY);
 
-  if (!userID || userID === "") {
+  if (!userToken || userToken === "") {
     const newUUID = createUUID();
     setCookie(COOKIE_KEY, newUUID, 10);
     return newUUID;
   }
-  setCookie(COOKIE_KEY, userID, 10);
-  return userID;
+  setCookie(COOKIE_KEY, userToken, 10);
+  return userToken;
 };
 
 /**
@@ -64,7 +64,6 @@ const createUUID = () => {
   });
 };
 
-const sessionID = createUUID;
-const userID = checkUserIdCookie;
+const userToken = checkUserIdCookie;
 
-export { sessionID, userID };
+export { userToken };

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -103,20 +103,19 @@ export function sendEvent(
     throw new Error("expected either `objectIDs` or `filters` to be provided");
   }
 
-  bulkSendEvent(this._applicationID, this._apiKey, [event]);
+  bulkSendEvent(this._applicationID, this._apiKey, this._endpointOrigin, [
+    event
+  ]);
 }
 
 function bulkSendEvent(
   applicationID: string,
   apiKey: string,
+  endpointOrigin: string,
   events: InsightsEvent[]
 ) {
-  const reportingQueryOrigin =
-    process.env.NODE_ENV === "production"
-      ? `https://insights.algolia.io/1/events`
-      : `http://localhost:8080/1/events`;
   // Auth query
-  const reportingURL = `${reportingQueryOrigin}?X-Algolia-Application-Id=${applicationID}&X-Algolia-API-Key=${apiKey}`;
+  const reportingURL = `${endpointOrigin}/1/events?X-Algolia-Application-Id=${applicationID}&X-Algolia-API-Key=${apiKey}`;
 
   // Detect navigator support
   const supportsNavigator = navigator && isFunction(navigator.sendBeacon);

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,11 +1,5 @@
 import { isNumber, isUndefined, isString, isFunction } from "./utils/index";
 
-declare var process: {
-  env: {
-    NODE_ENV: string;
-  };
-};
-
 export type InsightsEventType = "click" | "conversion";
 export type InsightsEvent = {
   eventType: InsightsEventType;

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -5,7 +5,7 @@ export type InsightsEvent = {
   eventType: InsightsEventType;
 
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -25,6 +25,9 @@ export function sendEvent(
   eventType: InsightsEventType,
   eventData: InsightsEvent
 ) {
+  if (this._userHasOptedOut) {
+    return;
+  }
   if (!this._hasCredentials) {
     throw new Error(
       "Before calling any methods on the analytics, you first need to call the 'init' function with applicationID and apiKey parameters"
@@ -41,14 +44,14 @@ export function sendEvent(
   if (!isUndefined(eventData.timestamp) && !isNumber(eventData.timestamp)) {
     throw TypeError("expected optional parameter `timestamp` to be a number");
   }
-  if (!isUndefined(eventData.userID) && !isString(eventData.userID)) {
-    throw TypeError("expected optional parameter `userID` to be a string");
+  if (!isUndefined(eventData.userToken) && !isString(eventData.userToken)) {
+    throw TypeError("expected optional parameter `userToken` to be a string");
   }
 
   const event: InsightsEvent = {
     eventType,
     eventName: eventData.eventName,
-    userID: eventData.userID || this._userID,
+    userToken: eventData.userToken || this._userToken,
     timestamp: eventData.timestamp || Date.now(),
     index: eventData.index
   };

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -2,7 +2,7 @@ import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchClickEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -15,10 +15,10 @@ export interface InsightsSearchClickEvent {
  * Sends a click report in the context of search
  * @param params: InsightsSearchClickEvent
  */
-export function clickedObjectIDInSearch(params: InsightsSearchClickEvent) {
+export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
   if (!params) {
     throw new Error(
-      "No params were sent to clickedObjectIDInSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
+      "No params were sent to clickedObjectIDsAfterSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
     );
   }
   if (!params.queryID) {
@@ -42,7 +42,7 @@ export function clickedObjectIDInSearch(params: InsightsSearchClickEvent) {
 
 export interface InsightsClickObjectIDsEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -53,10 +53,10 @@ export interface InsightsClickObjectIDsEvent {
  * Sends a click report using objectIDs
  * @param params: InsightsClickObjectIDsEvent
  */
-export function clickedObjectID(params: InsightsClickObjectIDsEvent) {
+export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
   if (!params) {
     throw new Error(
-      "No params were sent to clickedObjectID function, please provide `objectIDs` to be reported"
+      "No params were sent to clickedObjectIDs function, please provide `objectIDs` to be reported"
     );
   }
   if (!params.objectIDs) {
@@ -70,7 +70,7 @@ export function clickedObjectID(params: InsightsClickObjectIDsEvent) {
 
 export interface InsightsClickFiltersEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -2,7 +2,7 @@ import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchConversionEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -14,12 +14,12 @@ export interface InsightsSearchConversionEvent {
  * Sends a conversion report in the context of search
  * @param params InsightsSearchConversionEvent
  */
-export function convertedObjectIDInSearch(
+export function convertedObjectIDsAfterSearch(
   params: InsightsSearchConversionEvent
 ) {
   if (!params) {
     throw new Error(
-      "No params were sent to convertedObjectIDInSearch function, please provide `queryID` and `objectIDs` to be reported"
+      "No params were sent to convertedObjectIDsAfterSearch function, please provide `queryID` and `objectIDs` to be reported"
     );
   }
   if (!params.queryID) {
@@ -38,7 +38,7 @@ export function convertedObjectIDInSearch(
 
 export interface InsightsSearchConversionObjectIDsEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -67,7 +67,7 @@ export function convertedObjectIDs(
 
 export interface InsightsSearchConversionFiltersEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -6,8 +6,8 @@ const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
 export interface InitParams {
   apiKey: string;
   applicationID: string;
+  userHasOptedOut?: boolean;
   region?: InsightRegion;
-  endpointOrigin?: string;
 }
 
 /**
@@ -43,6 +43,7 @@ export function init(options: InitParams) {
 
   this._apiKey = options.apiKey;
   this._applicationID = options.applicationID;
+  this._userHasOptedOut = !!options.userHasOptedOut;
   this._region = options.region;
   this._endpointOrigin = options.region
     ? `https://insights.${options.region}.algolia.io`

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -7,21 +7,21 @@ objectAssignPolyfill();
 import { processQueue } from "./_processQueue";
 import { sendEvent, InsightsEventType, InsightsEvent } from "./_sendEvent";
 import { StorageManager } from "./_storageManager";
-import { userID } from "./_cookieUtils";
+import { userToken } from "./_cookieUtils";
 
 import { InitParams, init } from "./init";
 import { initSearch, InitSearchParams } from "./_initSearch";
 import {
   InsightsSearchClickEvent,
-  clickedObjectIDInSearch,
+  clickedObjectIDsAfterSearch,
   InsightsClickObjectIDsEvent,
-  clickedObjectID,
+  clickedObjectIDs,
   InsightsClickFiltersEvent,
   clickedFilters
 } from "./click";
 import {
   InsightsSearchConversionEvent,
-  convertedObjectIDInSearch,
+  convertedObjectIDsAfterSearch,
   InsightsSearchConversionObjectIDsEvent,
   convertedObjectIDs,
   InsightsSearchConversionFiltersEvent,
@@ -58,7 +58,8 @@ class AlgoliaAnalytics {
   _applicationID: string;
   _region: string;
   _endpointOrigin: string;
-  _userID: string;
+  _userToken: string;
+  _userHasOptedOut: boolean;
 
   // LocalStorage
   storageManager: StorageManager;
@@ -74,10 +75,10 @@ class AlgoliaAnalytics {
   // Public methods
   public init: (params: InitParams) => void;
   public initSearch: (params: InitSearchParams) => void;
-  public clickedObjectIDInSearch: (params?: InsightsSearchClickEvent) => void;
-  public clickedObjectID: (params?: InsightsClickObjectIDsEvent) => void;
+  public clickedObjectIDsAfterSearch: (params?: InsightsSearchClickEvent) => void;
+  public clickedObjectIDs: (params?: InsightsClickObjectIDsEvent) => void;
   public clickedFilters: (params?: InsightsClickFiltersEvent) => void;
-  public convertedObjectIDInSearch: (
+  public convertedObjectIDsAfterSearch: (
     params?: InsightsSearchConversionEvent
   ) => void;
   public convertedObjectIDs: (
@@ -109,18 +110,18 @@ class AlgoliaAnalytics {
     this.init = init.bind(this);
     this.initSearch = initSearch.bind(this);
 
-    this.clickedObjectIDInSearch = clickedObjectIDInSearch.bind(this);
-    this.clickedObjectID = clickedObjectID.bind(this);
+    this.clickedObjectIDsAfterSearch = clickedObjectIDsAfterSearch.bind(this);
+    this.clickedObjectIDs = clickedObjectIDs.bind(this);
     this.clickedFilters = clickedFilters.bind(this);
 
-    this.convertedObjectIDInSearch = convertedObjectIDInSearch.bind(this);
+    this.convertedObjectIDsAfterSearch = convertedObjectIDsAfterSearch.bind(this);
     this.convertedObjectIDs = convertedObjectIDs.bind(this);
     this.convertedFilters = convertedFilters.bind(this);
 
     this.viewedObjectIDs = viewedObjectIDs.bind(this);
     this.viewedFilters = viewedFilters.bind(this);
 
-    this._userID = userID();
+    this._userToken = userToken();
 
     // Process queue upon script execution
     this.processQueue();

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -2,7 +2,7 @@ import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 
@@ -29,7 +29,7 @@ export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
 
 export interface InsightsSearchViewFiltersEvent {
   eventName: string;
-  userID: string;
+  userToken: string;
   timestamp: number;
   index: string;
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,10 +23,7 @@ export default {
     buble(),
     commonjs(),
     uglify(),
-    filesize(),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-    })
+    filesize()
   ],
   targets: [
     { dest: `./dist/${LIBRARY_OUTPUT_NAME}.min.js`, format: 'umd' },


### PR DESCRIPTION
Target story:

> A developer should be able to choose the region he/she wants to use to send events

In the last PR https://github.com/algolia/search-insights.js/pull/40 we introduce region param and compute the endpoint origin.
In this PR, we use the endpoint.

i've also removed the process.env.NODE_ENV check from the codebase (partly addressing #23)