### PR TITLE
fix(timestamp): make timestamp optional

### DIFF
--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -214,7 +214,7 @@ describe("sendEvent", () => {
   });
 
   describe("timestamp", () => {
-    it("should add a timestamp if not provided", () => {
+    it("should not add a timestamp if not provided", () => {
       (AlgoliaInsights as any).sendEvent("click", {
         eventName: "my-event",
         index: "my-index",
@@ -222,13 +222,7 @@ describe("sendEvent", () => {
       });
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
-      expect(payload).toEqual({
-        events: [
-          expect.objectContaining({
-            timestamp: expect.any(Number)
-          })
-        ]
-      });
+      expect(payload.events[0]).not.toHaveProperty("timestamp");
     });
     it("should pass over provided timestamp", () => {
       (AlgoliaInsights as any).sendEvent("click", {

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -160,11 +160,11 @@ describe("Integration tests", () => {
         expect(event.objectIDs).toEqual([objectIDs]);
         expect(event.positions).toEqual([2]);
       });
-      it("should include an timestamp", () => {
+      it("should not include an timestamp as it was not passed", () => {
         const {
           events: [event]
         } = payload;
-        expect(event).toHaveProperty("timestamp");
+        expect(event).not.toHaveProperty("timestamp");
       });
     });
   });

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -41,9 +41,6 @@ export function sendEvent(
   if (!isString(eventData.index)) {
     throw TypeError("expected required parameter `index` to be a string");
   }
-  if (!isUndefined(eventData.timestamp) && !isNumber(eventData.timestamp)) {
-    throw TypeError("expected optional parameter `timestamp` to be a number");
-  }
   if (!isUndefined(eventData.userToken) && !isString(eventData.userToken)) {
     throw TypeError("expected optional parameter `userToken` to be a string");
   }
@@ -52,11 +49,17 @@ export function sendEvent(
     eventType,
     eventName: eventData.eventName,
     userToken: eventData.userToken || this._userToken,
-    timestamp: eventData.timestamp || Date.now(),
     index: eventData.index
   };
 
   // optional params
+  if (!isUndefined(eventData.timestamp)) {
+    if (!isNumber(eventData.timestamp)) {
+      throw TypeError("expected optional parameter `timestamp` to be a number");
+    }
+    event.timestamp = eventData.timestamp;
+  }
+
   if (!isUndefined(eventData.queryID)) {
     if (!isString(eventData.queryID)) {
       throw TypeError("expected optional parameter `queryID` to be a string");

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -3,7 +3,7 @@ import { InsightsEvent } from "./_sendEvent";
 export interface InsightsSearchClickEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   queryID: string;
@@ -43,7 +43,7 @@ export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
 export interface InsightsClickObjectIDsEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   objectIDs: (string | number)[];
@@ -71,7 +71,7 @@ export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
 export interface InsightsClickFiltersEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   filters: string[];

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,7 +1,7 @@
 export interface InsightsSearchConversionEvent {
   eventName: string;
-  userID: string;
-  timestamp: number;
+  userToken: string;
+  timestamp?: number;
   index: string;
 
   queryID: string;
@@ -37,7 +37,7 @@ export function convertedObjectIDsAfterSearch(
 export interface InsightsSearchConversionObjectIDsEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   objectIDs: (string | number)[];
@@ -67,7 +67,7 @@ export function convertedObjectIDs(
 export interface InsightsSearchConversionFiltersEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   filters: string[];

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -3,7 +3,7 @@ import { InsightsEvent } from "./_sendEvent";
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   objectIDs: (string | number)[];
@@ -30,7 +30,7 @@ export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
 export interface InsightsSearchViewFiltersEvent {
   eventName: string;
   userToken: string;
-  timestamp: number;
+  timestamp?: number;
   index: string;
 
   filters: string[];


### PR DESCRIPTION
This PR is a port of the fix that was made on 0.0.15.
It aims to allow the user not to send a timestamp in order to use the server-side generated timestamp.
User can still override the timestamp if wanted

fixes #46
fixes #32