### PR TITLE
fix(processQueue): extract globalObject from processQueue for easier testing

### DIFF
--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -13,7 +13,7 @@ const makeGlobalObject = () => {
   return globalObject;
 };
 
-class AlgoliaAnalytics {
+class FakeAlgoliaAnalytics {
   public init: Function;
   public otherMethod: Function;
   public processQueue: Function;
@@ -30,7 +30,7 @@ describe("processQueue", () => {
 
   beforeEach(() => {
     globalObject = makeGlobalObject();
-    insights = new AlgoliaAnalytics();
+    insights = new FakeAlgoliaAnalytics();
   });
 
   it("should forward method calls that happen before the queue is processed", () => {

--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -1,0 +1,61 @@
+import { processQueue } from "../_processQueue";
+
+const makeGlobalObject = () => {
+  // this is a simplified typescript tolerable version of the code we ask our
+  // customers to embed when installing the insights client in the browser.
+  // cf. https://github.com/algolia/search-insights.js#loading-and-initializing-the-library
+  const globalObject: any = {};
+  globalObject.AlgoliaAnalyticsObject = "aa";
+  globalObject.aa = function() {
+    globalObject.aa.queue = globalObject.aa.queue || [];
+    globalObject.aa.queue.push(arguments);
+  };
+  return globalObject;
+};
+
+class AlgoliaAnalytics {
+  public init: Function;
+  public otherMethod: Function;
+  public processQueue: Function;
+  constructor() {
+    this.init = jest.fn();
+    this.otherMethod = jest.fn(() => "otherMethodReturnedValue");
+    this.processQueue = processQueue.bind(this);
+  }
+}
+
+describe("processQueue", () => {
+  let insights;
+  let globalObject;
+
+  beforeEach(() => {
+    globalObject = makeGlobalObject();
+    insights = new AlgoliaAnalytics();
+  });
+
+  it("should forward method calls that happen before the queue is processed", () => {
+    globalObject.aa("init", { appID: "xxx", apiKey: "yyy" });
+    globalObject.aa("otherMethod", { objectIDs: ["1"] });
+
+    expect(insights.init).not.toHaveBeenCalled();
+    expect(insights.otherMethod).not.toHaveBeenCalled();
+
+    insights.processQueue(globalObject);
+
+    expect(insights.init).toHaveBeenCalledWith({ appID: "xxx", apiKey: "yyy" });
+    expect(insights.otherMethod).toHaveBeenCalledWith({ objectIDs: ["1"] });
+  });
+
+  it("should forward method calls that happen after the queue is processed", () => {
+    insights.processQueue(globalObject);
+
+    expect(insights.init).not.toHaveBeenCalled();
+    expect(insights.otherMethod).not.toHaveBeenCalled();
+
+    globalObject.aa("init", { appID: "xxx", apiKey: "yyy" });
+    globalObject.aa("otherMethod", { objectIDs: ["1"] });
+
+    expect(insights.init).toHaveBeenCalledWith({ appID: "xxx", apiKey: "yyy" });
+    expect(insights.otherMethod).toHaveBeenCalledWith({ objectIDs: ["1"] });
+  });
+});

--- a/lib/_processQueue.ts
+++ b/lib/_processQueue.ts
@@ -5,13 +5,13 @@
  * instead of putting them to the queue
  * @return {[type]} [description]
  */
-export function processQueue() {
+export function processQueue(globalObject) {
   // Set pointer which allows renaming of the script
-  const pointer = window["AlgoliaAnalyticsObject"] as any;
+  const pointer = globalObject["AlgoliaAnalyticsObject"] as any;
 
   // Check if there is a queue
   if (pointer) {
-    const queue = window[pointer].queue || [];
+    const queue = globalObject[pointer].queue || [];
 
     // Loop queue and execute functions in the queue
     queue.forEach((fn: string[]) => {
@@ -24,7 +24,7 @@ export function processQueue() {
     });
 
     // Reassign pointer
-    window[pointer] = (functionName: string, functionArguments: string) => {
+    globalObject[pointer] = (functionName: string, functionArguments: string) => {
       (this as any)[functionName](functionArguments);
     };
   }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -75,7 +75,7 @@ class AlgoliaAnalytics {
   version: string = version;
 
   // Private methods
-  private processQueue: () => void;
+  private processQueue: (globalObject: any) => void;
   private sendEvent: (
     eventType: InsightsEventType,
     data: InsightsEvent
@@ -140,7 +140,7 @@ class AlgoliaAnalytics {
 
     this.setUserToken(this.ANONYMOUS_USER_TOKEN);
     // Process queue upon script execution
-    this.processQueue();
+    this.processQueue(window);
   }
 }
 


### PR DESCRIPTION
This is adding some tests for processQueue which was untested until now.
I'm going to change it, so I'm preparing for it.