### PR TITLE
chore(tsc): add type-check for cmdline and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 before_script:
 - yarn install
 - yarn lint
+- yarn type-check
 script:
 - yarn build
 - yarn test

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "prettier": "prettier lib/**/*.ts examples/**/* --write",
     "test": "NODE_ENV=development yarn build:examples && yarn build && jest",
     "test:size": "bundlesize",
+    "type-check": "tsc",
+    "type-check:watch": "yarn type-check --watch",
     "version": "yarn build"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "noEmit": true,
     "outDir": "./dist/",
     "module": "es6",
     "target": "es6",


### PR DESCRIPTION
This adds a command that compiles the typescript code and checks the
types.
It is similar to the one that can be found in instantsearch.js:

https://github.com/algolia/instantsearch.js/blame/b3c2154d19bb8e50a07bdd0d5272eb8e3911279e/package.json#L34-L35

**UPDATE:**
pr build is breaking because of a rollup issue I located in the replace plugin.
The plugin has been remove here: https://github.com/algolia/search-insights.js/pull/113
This PR should build when the removal is live on develop.