### PR TITLE
chores(tooling): enable noUnusedLocals and strict

### DIFF
--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -76,11 +76,13 @@ class AlgoliaAnalytics {
 
   // Private methods
   private processQueue: (globalObject: any) => void;
-  private sendEvent: (
+
+  // Protected methods
+  protected sendEvent: (
     eventType: InsightsEventType,
     data: InsightsEvent
   ) => void;
-  private _hasCredentials: boolean = false;
+  protected _hasCredentials: boolean = false;
 
   // Public methods
   public init: (params: InitParams) => void;

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -74,10 +74,8 @@ class AlgoliaAnalytics {
 
   version: string = version;
 
-  // Private methods
   private processQueue: (globalObject: any) => void;
 
-  // Protected methods
   protected sendEvent: (
     eventType: InsightsEventType,
     data: InsightsEvent

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "noEmit": true,
+    "noUnusedLocals": true,
     "outDir": "./dist/",
     "module": "es6",
     "target": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
     "outDir": "./dist/",
     "module": "es6",
     "target": "es6",
+    "strict": true,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
     "noImplicitAny": false,
     "allowJs": true
   },


### PR DESCRIPTION
⚠️ this is to be merged after https://github.com/algolia/search-insights.js/pull/111

##### 1. enable `noUsusedLocals` 
This is the new way for catching unsued variable or imports.

It used to be something handle on tslint level but the [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) rule has been deprecated since tslint@5.11.0: see https://github.com/palantir/tslint/blob/master/CHANGELOG.md#warning-deprecations.

fixes #62 


##### 2. enable `strict` 
I had to opt-out of the following settings:

**noImplicitThis**

Adopting this one requires (at least) changes in every method.
At the moment, the main class AlgoliaAnalytics is split accross multiples files. Each method has is own file, more or less.

```ts
// in _sendEvent.ts
function sendEvent(params: any) {
    // reference to `this` is implicit
}

// in insights.ts
class AlgoliaAnalytics {
    protected _sendEvent;

    constructor() {
    	this._sendEvent = sendEvent.bind(this)
    }
}
```

If we want to enable noImplicitThis, we need to use a slightly different pattern

```ts
// in _sendEvent.ts
function sendEvent(this: AlgoliaAnalytics, params: any) {
    // reference to `this` is implicit
}

// in insights.ts
class AlgoliaAnalytics {
    protected _sendEvent;

    constructor() {
    	this._sendEvent = sendEvent.bind(this)
    }
}
```

More on that here: https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters

⚠️ There might be other changes required to enable this option. This is the most obvious one.

**strictNullChecks**

This is another one that will require various changes.
The errors raised when enabled are things like.

```
lib/insights.ts:67:3 - error TS2564: Property '_userToken' has no initializer and is not definitely assigned in the constructor.
   _userToken: string;
     ~~~~~~~~~~
```

```
lib/_sendEvent.ts:85:9 - error TS2532: Object is possibly 'undefined'.
     if (eventData.objectIDs.length !== eventData.positions.length) {
```

The first kind can be fixed by passing `this` parameter I think.
The second kind require to ~stop using `isUndefined` helper~ add type type-guards to `isUndefined` helper, as it turns out the first of the following code snippet will throw and error and then second will not.

```ts
    if (isUndefined(eventData.objectIDs)) throw new Error(‘...’)
    return eventData.objectIDs.length;
```
```ts
    if (typeof eventData.objectIDs === 'undefined’) throw new Error(‘...’)
    return eventData.objectIDs.length;
```

I've filed a Jira ticket to do this later.



