### PR TITLE
 feat(sendEvent): expose options.synchronous

### DIFF
--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -73,6 +73,45 @@ describe("sendEvent", () => {
         "X-Algolia-Application-Id": "testId"
       });
     });
+    it("should make a synchronous request when options.synchronous === true", () => {
+      (AlgoliaInsights as any).sendEvent(
+        "click",
+        {
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        { synchronous: true }
+      );
+      const [, , async] = XMLHttpRequest.open.mock.calls[0];
+      expect(async).toBe(false);
+    });
+    it("should make a asynchronous request when options.synchronous === false", () => {
+      (AlgoliaInsights as any).sendEvent(
+        "click",
+        {
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        { synchronous: false }
+      );
+      const [, , async] = XMLHttpRequest.open.mock.calls[0];
+      expect(async).toBe(true);
+    });
+    it("should make a asynchronous request when options.synchronous has no been passed", () => {
+      (AlgoliaInsights as any).sendEvent(
+        "click",
+        {
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        { someOtherOption: false }
+      );
+      const [, , async] = XMLHttpRequest.open.mock.calls[0];
+      expect(async).toBe(true);
+    });
   });
 
   describe("with sendBeacon", () => {
@@ -92,6 +131,20 @@ describe("sendEvent", () => {
       expect(sendBeacon).toHaveBeenCalledTimes(1);
       expect(XMLHttpRequest.open).not.toHaveBeenCalled();
       expect(XMLHttpRequest.send).not.toHaveBeenCalled();
+    });
+    it("should not use sendBeacon if options.synchronous === true", () => {
+      (AlgoliaInsights as any).sendEvent(
+        "click",
+        {
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        { synchronous: true }
+      );
+      expect(sendBeacon).not.toHaveBeenCalled();
+      expect(XMLHttpRequest.open).toHaveBeenCalledTimes(1);
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
     });
     it("should call sendBeacon with /1/event", () => {
       (AlgoliaInsights as any).sendEvent("click", {

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -5,7 +5,12 @@ objectKeysPolyfill();
 objectAssignPolyfill();
 
 import { processQueue } from "./_processQueue";
-import { sendEvent, InsightsEventType, InsightsEvent } from "./_sendEvent";
+import {
+  sendEvent,
+  InsightsEventType,
+  InsightsEvent,
+  InsightsOptions
+} from "./_sendEvent";
 
 import { InitParams, init } from "./init";
 import { initSearch, InitSearchParams } from "./_initSearch";
@@ -78,7 +83,8 @@ class AlgoliaAnalytics {
 
   protected sendEvent: (
     eventType: InsightsEventType,
-    data: InsightsEvent
+    data: InsightsEvent,
+    options?: InsightsOptions
   ) => void;
   protected _hasCredentials: boolean = false;
 


### PR DESCRIPTION
⚠️  this is not ready for review

When synchronous === true, synchronous XHR will be picked.
The purpose of this options if to give users more control in situations
where they want to navigate to another page.

```js
aa('sendEvent', {
   eventType: "click",
   ...

  },
  { synchronous: true }
)
```