### PR TITLE
fix(getCookie): support malformed cookie strings

### DIFF
--- a/lib/__tests__/_cookieUtils.test.ts
+++ b/lib/__tests__/_cookieUtils.test.ts
@@ -25,20 +25,5 @@ describe("cookieUtils", () => {
 
       expect(getCookie("_ALGOLIA")).toEqual("value");
     });
-    it("should return nothing when ALGOLIA cookie is malformed, and show a warning", () => {
-      const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
-
-      document.cookie = `_ALGOLIA=val%ue;expires=${DATE_TOMORROW};path=/`;
-      document.cookie = `BAD_COOKIE=val%ue;expires=${DATE_TOMORROW};path=/`;
-
-      expect(getCookie("_ALGOLIA")).toEqual("");
-      expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn).toHaveBeenCalledWith(
-        "Failed to decode _ALGOLIA cookie.",
-        expect.objectContaining({ name: "URIError" })
-      );
-
-      warn.mockRestore();
-    });
   });
 });

--- a/lib/__tests__/_cookieUtils.test.ts
+++ b/lib/__tests__/_cookieUtils.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getCookie } from "../_cookieUtils";
+
+const DAY = 86400000; /* 1 day in ms*/
+const DATE_TOMORROW = new Date(Date.now() + DAY).toUTCString();
+const DATE_YESTERDAY = new Date(Date.now() - DAY).toUTCString();
+
+describe("cookieUtils", () => {
+  beforeEach(() => {
+    // clean _ALGOLIA cookie
+    // the only way to clean a cookie is by setting it to a passed date.
+    document.cookie = `_ALGOLIA=value;expires=${DATE_YESTERDAY};path=/`;
+  });
+  describe("getCookie", () => {
+    it("should return '' _ALGOLIA cookie when not available", () => {
+      expect(getCookie("_ALGOLIA")).toEqual("");
+    });
+    it("should get _ALGOLIA cookie when available", () => {
+      document.cookie = `_ALGOLIA=value;expires=${DATE_TOMORROW};path=/`;
+
+      expect(getCookie("_ALGOLIA")).toEqual("value");
+    });
+  });
+});

--- a/lib/__tests__/_cookieUtils.test.ts
+++ b/lib/__tests__/_cookieUtils.test.ts
@@ -23,5 +23,26 @@ describe("cookieUtils", () => {
 
       expect(getCookie("_ALGOLIA")).toEqual("value");
     });
+    it("should not care about other cookie if malformed", () => {
+      document.cookie = `_ALGOLIA=value;expires=${DATE_TOMORROW};path=/`;
+      document.cookie = `BAD_COOKIE=val%ue;expires=${DATE_TOMORROW};path=/`;
+
+      expect(getCookie("_ALGOLIA")).toEqual("value");
+    });
+    it("should return nothing when ALGOLIA cookie is malformed, and show a warning", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
+
+      document.cookie = `_ALGOLIA=val%ue;expires=${DATE_TOMORROW};path=/`;
+      document.cookie = `BAD_COOKIE=val%ue;expires=${DATE_TOMORROW};path=/`;
+
+      expect(getCookie("_ALGOLIA")).toEqual("");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to decode _ALGOLIA cookie.",
+        expect.objectContaining({ name: "URIError" })
+      );
+
+      warn.mockRestore();
+    });
   });
 });

--- a/lib/__tests__/_cookieUtils.test.ts
+++ b/lib/__tests__/_cookieUtils.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { getCookie } from "../_cookieUtils";
 
 const DAY = 86400000; /* 1 day in ms*/

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -20,7 +20,7 @@ const setCookie = (cname: string, cvalue: string, exdays: number) => {
  * @param  {[type]} cname [description]
  * @return {[type]}       [description]
  */
-const getCookie = (cname: string):string => {
+export const getCookie = (cname: string):string => {
     var name = cname + "=";
     var decodedCookie = decodeURIComponent(document.cookie);
     var ca = decodedCookie.split(';');

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -29,12 +29,7 @@ export const getCookie = (cname: string): string => {
       c = c.substring(1);
     }
     if (c.indexOf(name) === 0) {
-      try {
-        return decodeURIComponent(c.substring(name.length, c.length));
-      } catch (e) {
-        console.warn(`Failed to decode ${cname} cookie.`, e);
-        return "";
-      }
+      return c.substring(name.length, c.length);
     }
   }
   return "";

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -21,23 +21,27 @@ const setCookie = (cname: string, cvalue: string, exdays: number) => {
  * @return {[type]}       [description]
  */
 export const getCookie = (cname: string):string => {
-    var name = cname + "=";
-    var decodedCookie = decodeURIComponent(document.cookie);
-    var ca = decodedCookie.split(';');
-    for(var i = 0; i <ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') {
+    const name = cname + "=";
+    const ca = document.cookie.split(';');
+    for(let i = 0; i <ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') {
             c = c.substring(1);
         }
-        if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
+        if (c.indexOf(name) === 0) {
+          try {
+            return decodeURIComponent(c.substring(name.length, c.length));
+          } catch (e) {
+            console.warn(`Failed to decode ${cname} cookie.`, e);
+            return "";
+          }
         }
     }
     return "";
 }
 
 /**
- * Return new UUID 
+ * Return new UUID
  * @return {[string]} new UUID
  */
 const checkUserIdCookie = (userSpecifiedID?: string|number):string => {

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -20,24 +20,24 @@ const setCookie = (cname: string, cvalue: string, exdays: number) => {
  * @param  {[type]} cname [description]
  * @return {[type]}       [description]
  */
-export const getCookie = (cname: string):string => {
-    const name = cname + "=";
-    const ca = document.cookie.split(';');
-    for(let i = 0; i <ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) === ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(name) === 0) {
-          try {
-            return decodeURIComponent(c.substring(name.length, c.length));
-          } catch (e) {
-            console.warn(`Failed to decode ${cname} cookie.`, e);
-            return "";
-          }
-        }
+export const getCookie = (cname: string): string => {
+  const name = cname + "=";
+  const ca = document.cookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === " ") {
+      c = c.substring(1);
     }
-    return "";
+    if (c.indexOf(name) === 0) {
+      try {
+        return decodeURIComponent(c.substring(name.length, c.length));
+      } catch (e) {
+        console.warn(`Failed to decode ${cname} cookie.`, e);
+        return "";
+      }
+    }
+  }
+  return "";
 }
 
 /**


### PR DESCRIPTION
**Summary** 

This makes the `getCookie()` not fail if the client happens to have malformed cookies we can't decode.
- decode only cookie of interest (cname cookie) rather than the whole
document.cookie string
- wrap decoding a try catch and return empty cookie with a warning.

NB: this is currently going to `0.x` (used on Magento 1 Algolia bundle).
I'll likely have to backport this to the dev branch and release it on `1.x`, although nobody complained about it so far.