### PR TITLE
fix(bug): persist function reference after library is loaded

### DIFF
--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -67,4 +67,11 @@ describe("processQueue", () => {
       callback
     );
   });
+
+  it("should use the same `aa` function after library loaded", () => {
+    const oldPointerFunction = globalObject.aa;
+    insights.processQueue(globalObject);
+    const newPointerFunction = globalObject.aa;
+    expect(oldPointerFunction).toStrictEqual(newPointerFunction);
+  });
 });

--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -72,6 +72,6 @@ describe("processQueue", () => {
     const oldPointerFunction = globalObject.aa;
     insights.processQueue(globalObject);
     const newPointerFunction = globalObject.aa;
-    expect(oldPointerFunction).toStrictEqual(newPointerFunction);
+    expect(oldPointerFunction).toBe(newPointerFunction);
   });
 });


### PR DESCRIPTION
Reassigning the pointer is a bad idea &mdash; see https://github.com/algolia/search-insights.js/issues/127. It's causing issues when `window.aa` is passed to InstantSearch or anything using it too early (before the library loaded)

This is a fix that doesn't require to change the install snippet. 
If you have a better idea, please let me know 😄 

fixes #127 