### PR TITLE
fix: remove startWith and use indexOf instead

### DIFF
--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -38,7 +38,7 @@ export function setUserToken(userToken: string | number): void {
     if (
       !foundToken ||
       foundToken === "" ||
-      !foundToken.startsWith("anonymous-")
+      foundToken.indexOf("anonymous-") !== 0
     ) {
       this._userToken = `anonymous-${createUUID()}`;
       setCookie(COOKIE_KEY, this._userToken, this._cookieDuration);


### PR DESCRIPTION
This PR removes `startWith` from `_cookieUtils.ts`. It was throwing an error in IE10.
After this fix, I've confirmed it's working fine in BrowserStack.