### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## [1.2.1](https://github.com/algolia/search-insights.js/compare/v1.2.0...v1.2.1) (2019-07-23)
+
+
+### Bug Fixes
+
+* **getUserToken:** add integration tests ([#114](https://github.com/algolia/search-insights.js/issues/114)) ([c02c178](https://github.com/algolia/search-insights.js/commit/c02c178))
+* **processQueue:** move callback on method level ([#115](https://github.com/algolia/search-insights.js/issues/115)) ([1ff8191](https://github.com/algolia/search-insights.js/commit/1ff8191))
+* remove startWith and use indexOf instead ([#129](https://github.com/algolia/search-insights.js/issues/129)) ([9c79e20](https://github.com/algolia/search-insights.js/commit/9c79e20))
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-insights",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Search analytics by Algolia",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.min.js",


### PR DESCRIPTION
## Release Summary
- Version change: `v1.2.0` → `v1.2.1`
- Merge: `releases/v1.2.1` → `chore/add-shipjs`
- [Compare the changes between the versions](https://github.com/algolia/search-insights.js/compare/v1.2.0...releases/v1.2.1)