### PR TITLE
chore: add dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NODE_ENV=production
+INDEX_NAME=instant_search
+APP_ID=latency
+API_KEY=xxx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 tests/screenshots
 tests/production
 tests/data.txt
+.env

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -3,12 +3,15 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlReplaceWebpackPlugin = require('html-replace-webpack-plugin');
+require('dotenv').config();
 
 const isProd = process.env.NODE_ENV === "production";
 const { NODE_ENV, APP_ID, API_KEY, INDEX_NAME } = process.env;
 if ([NODE_ENV, APP_ID, API_KEY, INDEX_NAME].some(v => !Boolean(v))) {
   console.error(`The following environment variables are required:`);
   console.error(`  > NODE_ENV, APP_ID, API_KEY, INDEX_NAME`);
+  console.error(`You can either specify them when running command,`);
+  console.error(`or create .env file to store them locally.`);
   console.error('')
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bundlesize": "0.18.0",
     "cors": "2.8.5",
     "css-loader": "0.28.11",
-    "dotenv": "^8.0.0",
+    "dotenv": "8.0.0",
     "express": "4.17.1",
     "extract-text-webpack-plugin": "3.0.2",
     "html-loader": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bundlesize": "0.18.0",
     "cors": "2.8.5",
     "css-loader": "0.28.11",
+    "dotenv": "^8.0.0",
     "express": "4.17.1",
     "extract-text-webpack-plugin": "3.0.2",
     "html-loader": "0.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,7 +2783,7 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dotenv@^8.0.0:
+dotenv@8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
   integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,6 +2783,11 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"


### PR DESCRIPTION
This PR adds `dotenv` to devDependencies.
Instead of running `NODE_ENV=production INDEX_NAME=xxx APP_ID=yyy API_KEY=zzz yarn dev` every time,
we can create a file `.env` and put the following as the content:

```
NODE_ENV=production
INDEX_NAME=xxx
APP_ID=yyy
API_KEY=zzz
```

`.env` is included in `.gitignore`, so won't be commited, but used only locally.