### PR TITLE
feat: node compatibility [PART-1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "description": "Search analytics by Algolia",
   "jsdelivr": "dist/search-insights.min.js",
-  "main": "dist/search-insights.min.js",
+  "main": "dist/search-insights.cjs.min.js",
+  "browser": "dist/search-insights.min.js",
   "files": [
     "dist",
     "lib",
@@ -19,6 +20,7 @@
     "lint:fix": "yarn lint -- --fix",
     "prettier": "prettier lib/**/*.ts examples/**/* --write",
     "test": "NODE_ENV=development yarn build:examples && yarn build && jest",
+    "test:watch": "yarn test --watch",
     "test:size": "bundlesize",
     "type-check": "tsc",
     "type-check:watch": "yarn type-check --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,34 +1,49 @@
-
-import buble from 'rollup-plugin-buble';
-import filesize from 'rollup-plugin-filesize';
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
-import uglify from 'rollup-plugin-uglify';
+import buble from "rollup-plugin-buble";
+import filesize from "rollup-plugin-filesize";
+import resolve from "rollup-plugin-node-resolve";
+import commonjs from "rollup-plugin-commonjs";
+import uglify from "rollup-plugin-uglify";
 import json from "rollup-plugin-json";
-import typescript from 'rollup-plugin-typescript';
+import typescript from "rollup-plugin-typescript";
 
-const MODULE_NAME = 'AlgoliaAnalytics', LIBRARY_OUTPUT_NAME = 'search-insights';
+const MODULE_NAME = "AlgoliaAnalytics",
+  LIBRARY_OUTPUT_NAME = "search-insights";
 
-export default {
-  entry: 'lib/insights.ts',
-  format: 'umd',
-  moduleName: MODULE_NAME,
-  plugins: [
-    typescript(),
-    resolve({
-      browser: true,
-      preferBuiltins: false,
-    }),
-    json({
-      preferConst: true,
-      compact: true
-    }),
-    buble(),
-    commonjs(),
-    uglify(),
-    filesize()
-  ],
-  targets: [
-    { dest: `./dist/${LIBRARY_OUTPUT_NAME}.min.js`, format: 'umd' },
-  ],
-};
+const createPlugins = ({ browser }) => [
+  typescript(),
+  resolve({
+    browser,
+    preferBuiltins: false
+  }),
+  json({
+    preferConst: true,
+    compact: true
+  }),
+  buble(),
+  commonjs(),
+  uglify(),
+  filesize()
+];
+
+export default [
+  {
+    input: "lib/insights.ts",
+    output: {
+      format: "umd",
+      name: MODULE_NAME,
+      file: `./dist/${LIBRARY_OUTPUT_NAME}.min.js`,
+      globals: {}
+    },
+    plugins: createPlugins({ browser: true })
+  },
+  {
+    input: "lib/insights.ts",
+    output: {
+      format: "cjs",
+      name: MODULE_NAME,
+      file: `./dist/${LIBRARY_OUTPUT_NAME}.cjs.min.js`
+    },
+    external: ["http"],
+    plugins: createPlugins({ browser: false })
+  }
+];

--- a/tests/data.txt
+++ b/tests/data.txt
@@ -1,7 +1,0 @@
-{"objectID":"81","position":2,"queryID":"63c49a92c151f15001aae3ad42286dc2","timestamp":1518197121357,"userID":"43fed8a6-7b64-424d-a764-1361e3aa103b"}
-{"objectID":"81","position":2,"queryID":"dbe249ff408164942554c386e3f4dc91","timestamp":1519729943581,"userID":"bcd71638-c214-4252-82a6-98bae87d8c8f"}
-{"events":[{"objectID":"3828012","position":2,"queryID":"d805d41243319c0d2fb4e0a4a3a666a9","timestamp":1543420719930,"userID":"cbbf8eba-d8a5-4269-b3d0-7448617eee6e","eventType":"click"}]}
-{"events":[{"objectID":"3828012","position":2,"queryID":"f904bf83e00f3753038f5902a7ade1c2","timestamp":1543420848078,"userID":"2e59c250-354d-4665-ae11-ff18a1aef0ca","eventType":"click"}]}
-{"events":[{"eventType":"click","eventName":"hit-clicked","userToken":"anonymous-f3aeb271-56d1-4f25-b99b-fd9a76e445f6","index":"instant_search","queryID":"f1c16a5bca64062addf73f464803d211","objectIDs":["3828012"],"positions":[2]}]}
-{"events":[{"eventType":"click","eventName":"hit-clicked","userToken":"anonymous-e03405de-772d-4cc3-b705-7d1fc09a3718","index":"instant_search","queryID":"975350a6a27f431fdf8aa75bd967ffcb","objectIDs":["3828012"],"positions":[2]}]}
-{"events":[{"eventType":"click","eventName":"hit-clicked","userToken":"anonymous-ed89c735-f217-4834-a4be-257a1a4ecb38","index":"instant_search","queryID":"aaa6ff299f2d8deb0e406081eb785854","objectIDs":["3828012"],"positions":[2]}]}


### PR DESCRIPTION
## [PART-1] - rollup config

This PR modifies the rollup config so that it can produce two builds, one for umd and another one for cjs.

### Note

I thought it's unnecessary to have codes like `document.cookie` in the build output for node environment, then realized there is no way to figure out the environment in the building stage because `cjs` build can be used both in node and browser.

So the final rollup config is just building cjs and umd with no special configuration.

### Stacked PRs

```
Part1. rollup config  ------- Part2. disable anonymous tracking on env without cookie
                      \______ Part3. fallbacks of sendBeacon
```