### PR TITLE
chore: add jest watch typeahead plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "instantsearch.js": "2.10.5",
     "jest": "24.8.0",
     "jest-localstorage-mock": "2.4.0",
+    "jest-watch-typeahead": "^0.3.1",
     "lunr": "2.3.6",
     "node-sass": "4.12.0",
     "prettier": "1.18.2",
@@ -95,6 +96,10 @@
       "js",
       "jsx",
       "json"
+    ],
+    "watchPlugins": [
+      "jest-watch-typeahead/filename",
+      "jest-watch-typeahead/testname"
     ]
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "instantsearch.js": "2.10.5",
     "jest": "24.8.0",
     "jest-localstorage-mock": "2.4.0",
-    "jest-watch-typeahead": "^0.3.1",
+    "jest-watch-typeahead": "0.3.1",
     "lunr": "2.3.6",
     "node-sass": "4.12.0",
     "prettier": "1.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,7 +5031,19 @@ jest-validate@^24.8.0:
     leven "^2.1.0"
     pretty-format "^24.8.0"
 
-jest-watcher@^24.8.0:
+jest-watch-typeahead@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.3.1.tgz#47701024b64b444aa325d801b4b3a6d61ed70701"
+  integrity sha512-cDIko96c4Yqg/7mfye1eEYZ6Pvugo9mnOOhGQod3Es7/KptNv1b+9gFVaotzdqNqTlwbkA80BnWHtzV4dc+trA==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.4.1"
+    jest-watcher "^24.3.0"
+    slash "^2.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^5.0.0"
+
+jest-watcher@^24.3.0, jest-watcher@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.8.0.tgz#58d49915ceddd2de85e238f6213cef1c93715de4"
   integrity sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,7 +5031,7 @@ jest-validate@^24.8.0:
     leven "^2.1.0"
     pretty-format "^24.8.0"
 
-jest-watch-typeahead@^0.3.1:
+jest-watch-typeahead@0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.3.1.tgz#47701024b64b444aa325d801b4b3a6d61ed70701"
   integrity sha512-cDIko96c4Yqg/7mfye1eEYZ6Pvugo9mnOOhGQod3Es7/KptNv1b+9gFVaotzdqNqTlwbkA80BnWHtzV4dc+trA==


### PR DESCRIPTION
This PR adds [typeahead](https://github.com/jest-community/jest-watch-typeahead) plugin to jest.