### PR TITLE
chore: update release script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
 - yarn build
 - yarn test
 - yarn test:size
-- yarn shipjs:release
+- yarn release:trigger
 addons:
   artifacts:
     paths:

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "type-check": "tsc",
     "type-check:watch": "yarn type-check --watch",
-    "shipjs:prepare": "shipjs prepare",
-    "shipjs:release": "shipjs release"
+    "release:prepare": "shipjs prepare",
+    "release:trigger": "shipjs release"
   },
   "repository": {
     "type": "git",
@@ -78,7 +78,7 @@
     "rollup-plugin-typescript": "1.0.1",
     "rollup-plugin-uglify": "3.0.0",
     "sass-loader": "6.0.7",
-    "shipjs": "0.3.2",
+    "shipjs": "^0.6.0",
     "style-loader": "0.23.1",
     "ts-jest": "22.4.6",
     "ts-loader": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rollup-plugin-typescript": "1.0.1",
     "rollup-plugin-uglify": "3.0.0",
     "sass-loader": "6.0.7",
-    "shipjs": "^0.6.0",
+    "shipjs": "0.6.0",
     "style-loader": "0.23.1",
     "ts-jest": "22.4.6",
     "ts-loader": "6.0.4",

--- a/ship.config.js
+++ b/ship.config.js
@@ -5,5 +5,6 @@ module.exports = {
       develop: "master"
     }
   },
-  buildCommand: () => "yarn build && /bin/bash ./pre-deploy.sh"
+  buildCommand: () => "yarn build && /bin/bash ./pre-deploy.sh",
+  pullRequestReviewer: "@algolia/instantsearch-for-websites"
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,7 +3095,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@8.1.0:
+dotenv@8.1.0, dotenv@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
   integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
@@ -4536,10 +4536,10 @@ ini@^1.3.2, ini@~1.3.0:
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inquirer@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz#8bfb7a5ac02dac6ff641ac4c5ff17da112fcdb42"
-  integrity sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==
+inquirer@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz#9e2b032dde77da1db5db804758b8fea3a970519a"
+  integrity sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^2.4.2"
@@ -8490,19 +8490,20 @@ shellwords@^0.1.1:
   resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shipjs-lib@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.3.2.tgz#987c737c759ef4e366b09625309013bade116776"
-  integrity sha512-2DxEgM2g4nesguoYKqMTwTje679YDeSq6JGXpj2nERfwze/rXD/3tMKB+uSKVrUtC49lukNB2gmKPVq/a9TVrg==
+shipjs-lib@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.6.0.tgz#12a727d62e5d47c497a74fe0a608a9143892c4d3"
+  integrity sha512-QqRpWuI1PdRGSTdEzx+GRZzEDRcnCfXnkVpMac8PsucrWKt481aTpkaTk6HHzTX0fqbd5H7pqg8OUuoGyUZjYg==
   dependencies:
+    dotenv "^8.1.0"
     parse-github-url "1.0.2"
     semver "6.3.0"
     shelljs "0.8.3"
 
-shipjs@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.3.2.tgz#eb2c8cdefb1d3e3d5ce994fbd305d08df907322d"
-  integrity sha512-Nb+mqjAQ033KJpFTc3p5Bv8Q+mQajP8VWsSl7N8VR8rmlxyex91vAX5oSI6O8eBPoUXRdvg9KJj20RUTgKWkrg==
+shipjs@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.6.0.tgz#e104ac66643fb3888572be870c42acdaae23e470"
+  integrity sha512-juQ+K1OzqlO5JFt70Vd+X1UsuYuDdxEVioDKzxUiH7+Iq/4xfzeErbTdWsUNDlXIhwdZEcXmZ8ZcbICynpIydA==
   dependencies:
     "@slack/webhook" "^5.0.1"
     arg "4.1.1"
@@ -8510,8 +8511,8 @@ shipjs@0.3.2:
     change-case "3.1.0"
     conventional-changelog-cli "2.0.23"
     esm "3.2.25"
-    inquirer "6.5.1"
-    shipjs-lib "0.3.2"
+    inquirer "7.0.0"
+    shipjs-lib "0.6.0"
     temp-write "4.0.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,7 +8500,7 @@ shipjs-lib@0.6.0:
     semver "6.3.0"
     shelljs "0.8.3"
 
-shipjs@^0.6.0:
+shipjs@0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.6.0.tgz#e104ac66643fb3888572be870c42acdaae23e470"
   integrity sha512-juQ+K1OzqlO5JFt70Vd+X1UsuYuDdxEVioDKzxUiH7+Iq/4xfzeErbTdWsUNDlXIhwdZEcXmZ8ZcbICynpIydA==


### PR DESCRIPTION
This PR updates the version of `Ship.js` to the latest.
Its command `shipjs release` has been renamed to `shipjs trigger`
and a few bugs have been fixed.

This also configures Ship.js to auto-assign `@algolia/instantsearch-for-websites` team when creating a PR.