### PR TITLE
docs(gtm): link to the official documentation

### DIFF
--- a/gtm/README.md
+++ b/gtm/README.md
@@ -1,93 +1,10 @@
 # Search Insights for Google Tag Manager (GTM)
 
-Google Tag Manager [custom template](https://developers.google.com/tag-manager/templates/) for Algolia Search Insights.
+Google Tag Manager connector for Algolia Search Insights.
 
----
+## Documentation
 
-<div align="center">
-
-[**Download template**](generated/search-insights.tpl)
-
-</div>
-
----
-
-## Usage
-
-### 1. Import the template
-
-- Download **[`search-insights.tpl`](generated/search-insights.tpl)**
-- Import the file in [Google Tag Manager](https://tagmanager.google.com)
-  - Go to "Templates"
-  - Click on "New"
-  - Select "Import" in the menu
-
-### 2. Create variables
-
-For events to be sent with the correct information (`userToken`, `objectIDs`, `queryID`, etc.), you need to add variables in the "User-Defined Variables" section.
-
-1. Click "New" in the Variables panel
-1. Name the variable (e.g. "ItemClicked", "UserToken", etc.)
-1. Set the variable type:
-   - "Custom JavaScript" if coming from [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) (e.g. `objectIDs`, `positions`, `queryId` etc.)
-   - "Data Layer Variable" if coming from a [Data Layer](https://developers.google.com/tag-manager/devguide#datalayer) (e.g. `userToken`)
-
-[Learn more about GTM variables →](https://www.simoahava.com/analytics/variable-guide-google-tag-manager/)
-
-### 3. Create tags
-
-1. Click "New" in the Tags panel
-1. Select the tag type "Algolia Search Insights"
-1. Choose the event type and provide the Search Insights options
-1. Select the trigger for this event
-
-## FAQ
-
-### How to get the user token?
-
-The user token can be forwarded to GTM via a [Data Layer](https://developers.google.com/tag-manager/devguide#datalayer).
-
-```js
-window.dataLayer = window.dataLayer || [];
-window.dataLayer.push({
-  userToken: 'USER_1',
-});
-```
-
-### How to get the object IDs, positions and query ID?
-
-The `objectIDs`, `positions` and `queryID` can be forwarded to GTM via [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).
-
-```js
-instantsearch.widgets.hits({
-  container: '#hits',
-  templates: {
-    item: `
-<article
- data-insights-object-id="{{objectID}}"
- data-insights-position="{{__position}}"
- data-insights-query-id="{{__queryID}}"
->
-  <!-- ... -->
-</article>
-`,
-  },
-});
-```
-
-> `__queryID` and `__position` are available from:
->
-> - InstantSearch.js 3.4.0
-> - React InstantSearch 5.5.0
-> - Vue InstantSearch 2.1.0
-> - Angular InstantSearch 3.0.0
-
-### How to change the Search Insights source URL?
-
-By default, the Search Insights source URL targets [jsDelivr CDN](https://www.jsdelivr.com/). If you want to use a specific version of the Search Insights library or to host your own version of the library, you can change the URL:
-
-1. In the "Init" event configuration, go to "Advanced Algolia Settings" and update "Search Insights Source URL"
-1. In the "Permissions" template, add the same link in the "[Inject Scripts](https://www.simoahava.com/analytics/custom-templates-guide-for-google-tag-manager/#injects-scripts)" section
+Head over our [Getting Insights and Analytics / Google Tag Manager](https://www.algolia.com/doc/guides/getting-insights-and-analytics/connectors/google-tag-manager/) documentation.
 
 ## Contributing
 

--- a/gtm/README.md
+++ b/gtm/README.md
@@ -4,7 +4,7 @@ Google Tag Manager connector for Algolia Search Insights.
 
 ## Documentation
 
-Head over our [Getting Insights and Analytics / Google Tag Manager](https://www.algolia.com/doc/guides/getting-insights-and-analytics/connectors/google-tag-manager/) documentation.
+Head over our [**Getting Insights and Analytics / Google Tag Manager**](https://www.algolia.com/doc/guides/getting-insights-and-analytics/connectors/google-tag-manager/) documentation.
 
 ## Contributing
 


### PR DESCRIPTION
This alternative closes #173 by linking to the [official documentation](https://www.algolia.com/doc/guides/getting-insights-and-analytics/connectors/google-tag-manager/) that is now available on the Algolia website.