### PR TITLE
fix(types): remove optional types on main methods

### DIFF
--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -95,22 +95,22 @@ class AlgoliaAnalytics {
   ) => string;
 
   public clickedObjectIDsAfterSearch: (
-    params?: InsightsSearchClickEvent
+    params: InsightsSearchClickEvent
   ) => void;
-  public clickedObjectIDs: (params?: InsightsClickObjectIDsEvent) => void;
-  public clickedFilters: (params?: InsightsClickFiltersEvent) => void;
+  public clickedObjectIDs: (params: InsightsClickObjectIDsEvent) => void;
+  public clickedFilters: (params: InsightsClickFiltersEvent) => void;
   public convertedObjectIDsAfterSearch: (
-    params?: InsightsSearchConversionEvent
+    params: InsightsSearchConversionEvent
   ) => void;
   public convertedObjectIDs: (
-    params?: InsightsSearchConversionObjectIDsEvent
+    params: InsightsSearchConversionObjectIDsEvent
   ) => void;
   public convertedFilters: (
-    params?: InsightsSearchConversionFiltersEvent
+    params: InsightsSearchConversionFiltersEvent
   ) => void;
 
-  public viewedObjectIDs: (params?: InsightsSearchViewObjectIDsEvent) => void;
-  public viewedFilters: (params?: InsightsSearchViewFiltersEvent) => void;
+  public viewedObjectIDs: (params: InsightsSearchViewObjectIDsEvent) => void;
+  public viewedFilters: (params: InsightsSearchViewFiltersEvent) => void;
 
   constructor({ requestFn }: { requestFn: RequestFnType }) {
     // Bind private methods to `this` class


### PR DESCRIPTION
This remove `?` on the parameter `param`. It's rather a typo fix.
CI runs the type-check job which will ensure this compiles.

This closes: https://github.com/algolia/search-insights.js/issues/53