### PR TITLE
chore: remove NODE_ENV from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-NODE_ENV=production
 INDEX_NAME=instant_search
 APP_ID=latency
 API_KEY=xxx

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
     "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
-    "build:examples": "NODE_ENV=production webpack --config config/webpack.config.js --color --progress",
+    "build:examples": "webpack --config config/webpack.config.js --color --progress",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",
     "lint": "tslint ./lib/**/*.ts",
     "lint:fix": "yarn lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
     "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
-    "build:examples": "webpack --config config/webpack.config.js --color --progress",
+    "build:examples": "NODE_ENV=production webpack --config config/webpack.config.js --color --progress",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",
     "lint": "tslint ./lib/**/*.ts",
     "lint:fix": "yarn lint -- --fix",


### PR DESCRIPTION
This PR removes unnecessary `NODE_ENV=production` from `.env.example`.