### PR TITLE
feat(sendEvent): return the value of the request function

### DIFF
--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -126,7 +126,7 @@ export function makeSendEvent(requestFn: RequestFnType) {
       );
     }
 
-    bulkSendEvent(
+    return bulkSendEvent(
       requestFn,
       this._appId,
       this._apiKey,
@@ -147,5 +147,5 @@ function bulkSendEvent(
 ) {
   // Auth query
   const reportingURL = `${endpointOrigin}/1/events?X-Algolia-Application-Id=${appId}&X-Algolia-API-Key=${apiKey}&X-Algolia-Agent=${userAgent}`;
-  requestFn(reportingURL, { events });
+  return requestFn(reportingURL, { events });
 }


### PR DESCRIPTION
The existing request functions return undefined, so this isn't a breaking change, but this allows you to have a custom requester you can wait on (e.g. fetch).

fixes #199