### PR TITLE
chore: remove browser from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.4.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
-  "browser": "dist/search-insights.min.js",
   "engines": {
     "node": ">=8.16.0"
   },


### PR DESCRIPTION
This PR removes `browser` key from `package.json`.
When `search-insights` is loaded by `require` or `import`, umd version is still loaded because of `browser`.

- before this PR: https://codesandbox.io/s/wonderful-sammet-s2p7k?file=/src/index.js
- in this PR: https://codesandbox.io/s/vibrant-antonelli-wv3zr?file=/src/index.js

cjs build [exports a function](https://github.com/algolia/search-insights.js/blob/chore/remove-browser/lib/node.ts#L9:L9), but if you try with "before this PR" sandbox, you can see an object is imported (which means it's a umd build).

I also downloaded the sandbox and modified the dist/ files to see which one is loaded, to make sure.

I guess it's safe to remove `browser`, because we specifically guide to use `jsdeliver` in case of umd and we don't have `browser` in InstantSearch libraries.