### PR TITLE
Fix types

### DIFF
--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -5,7 +5,7 @@ export type InsightsEventType = "click" | "conversion" | "view";
 export type InsightsEvent = {
   eventType: InsightsEventType;
 
-  eventName?: string;
+  eventName: string;
   userToken: string;
   timestamp?: number;
   index: string;

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchClickEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchConversionEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;

--- a/package.json
+++ b/package.json
@@ -4,18 +4,21 @@
   "version": "1.4.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=8.16.0"
   },
   "files": [
     "dist",
     "lib",
+    "types",
     "!**/__tests__/**"
   ],
   "scripts": {
-    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
-    "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
+    "build": "yarn build:types && rollup --environment NODE_ENV:'production' -c rollup.config.js",
+    "build:dev": "yarn build:types && rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
     "build:examples": "webpack --config config/webpack.config.js --color --progress",
+    "build:types": "tsc -p . --noEmit false && rimraf dist",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",
     "lint": "tslint ./lib/**/*.ts",
     "lint:fix": "yarn lint -- --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "declaration": true,
+    "declarationDir": "./types",
     "noEmit": true,
     "noUnusedLocals": true,
     "outDir": "./dist/",
@@ -11,7 +13,9 @@
     "noImplicitThis": false,
     "strictNullChecks": false,
     "noImplicitAny": false,
-    "allowJs": true
+    "allowJs": true,
+    "rootDir": "."
   },
+  "include": ["lib/browser.ts", "lib/node.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
- Adds typescript definition output
- Fixes missing required eventName interface property

_sendEvent identifies the eventName property as optional, and then does a type assertion on it in code, therefore making it required, even if empty. Requiring it on all higher level interfaces to avoid these type checking issues