### PR TITLE
fix(types): add definition output and require eventName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 types/
+lib/**/*.js
 node_modules
 tests/screenshots
 tests/production

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 dist/
-types/
-lib/**/*.js
 node_modules
 tests/screenshots
 tests/production

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+types/
 node_modules
 tests/screenshots
 tests/production

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -5,7 +5,7 @@ export type InsightsEventType = "click" | "conversion" | "view";
 export type InsightsEvent = {
   eventType: InsightsEventType;
 
-  eventName?: string;
+  eventName: string;
   userToken: string;
   timestamp?: number;
   index: string;

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchClickEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchConversionEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "version": "1.4.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
-  "types": "types/lib/node.d.ts",
+  "types": "dist/lib/node.d.ts",
   "engines": {
     "node": ">=8.16.0"
   },
   "files": [
     "dist",
     "lib",
-    "types",
     "!**/__tests__/**"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:types && rollup --environment NODE_ENV:'production' -c rollup.config.js",
     "build:dev": "yarn build:types && rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
     "build:examples": "webpack --config config/webpack.config.js --color --progress",
-    "build:types": "tsc -p . --noEmit false && rimraf dist",
+    "build:types": "tsc -p . --noEmit false",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",
     "lint": "tslint ./lib/**/*.ts",
     "lint:fix": "yarn lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -4,18 +4,21 @@
   "version": "1.4.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=8.16.0"
   },
   "files": [
     "dist",
     "lib",
+    "types",
     "!**/__tests__/**"
   ],
   "scripts": {
-    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
-    "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
+    "build": "yarn build:types && rollup --environment NODE_ENV:'production' -c rollup.config.js",
+    "build:dev": "yarn build:types && rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
     "build:examples": "webpack --config config/webpack.config.js --color --progress",
+    "build:types": "tsc -p . --noEmit false && rimraf dist",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",
     "lint": "tslint ./lib/**/*.ts",
     "lint:fix": "yarn lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
-  "types": "types/index.d.ts",
+  "types": "types/lib/node.d.ts",
   "engines": {
     "node": ">=8.16.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "rootDir": "."
   },
   "include": ["lib/browser.ts", "lib/node.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "declaration": true,
+    "declarationDir": "./types",
     "noEmit": true,
     "noUnusedLocals": true,
     "outDir": "./dist/",
@@ -11,7 +13,9 @@
     "noImplicitThis": false,
     "strictNullChecks": false,
     "noImplicitAny": false,
-    "allowJs": true
+    "allowJs": true,
+    "rootDir": "."
   },
+  "include": ["lib/browser.ts", "lib/node.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,18 +3,19 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "declaration": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist",
     "noEmit": true,
     "noUnusedLocals": true,
     "outDir": "./dist/",
-    "module": "es6",
-    "target": "es6",
+    "module": "commonjs",
+    "target": "es5",
     "strict": true,
     "noImplicitThis": false,
     "strictNullChecks": false,
     "noImplicitAny": false,
     "allowJs": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "baseUrl": "lib"
   },
   "include": ["lib/browser.ts", "lib/node.ts"],
   "exclude": ["node_modules", "**/*.test.ts", "dist"]


### PR DESCRIPTION
- Adds typescript definition output
- Fixes missing required eventName interface property

_sendEvent identifies the eventName property as optional, and then does a type assertion on it in code, therefore making it required, even if empty. Requiring it on all higher level interfaces to avoid these type checking issues

This should also address the concerns of #9 