### PR TITLE
feat: add onUserTokenChange to know when token is assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,32 @@ aa('getUserToken', null, (err, userToken) => {
 });
 ```
 
+#### Listen to `userToken` change
+
+If you want to attach a listener for `userToken` change, you can call `onUserTokenChange`.
+
+```js
+aa('onUserTokenChange', (userToken) => {
+  console.log("userToken has changed: ", userToken);
+});
+```
+
+`onUserTokenChange` accepts `callback`(required) and `options`(optional).
+
+```js
+aa('onUserTokenChange', callback, options);
+```
+
+| Option      | Type       | Description                                    |
+| ----------- | ---------- | ---------------------------------------------- |
+| `immediate` | `boolean`  | Fire the callback as soon as it's attached     |
+
+If there is a chance that userToken is already set before `onUserTokenChange`, then you can provide `{ immediate: true }` option in order to get the token as soon as you attach `onUserTokenChange`.
+
+```js
+aa('onUserTokenChange', callback, { immediate: true });
+```
+
 #### Report a click event
 
 ```js

--- a/README.md
+++ b/README.md
@@ -219,11 +219,24 @@ aa('onUserTokenChange', callback, options);
 | ----------- | ---------- | ---------------------------------------------- |
 | `immediate` | `boolean`  | Fire the callback as soon as it's attached     |
 
-If there is a chance that userToken is already set before `onUserTokenChange`, then you can provide `{ immediate: true }` option in order to get the token as soon as you attach `onUserTokenChange`.
+```js
+aa('init', { ... });  // ← This sets an anonymous user token if cookie is available.
+
+aa('onUserTokenChange', (userToken) => {
+  console.log(userToken);  // prints out the anonymous user token
+}, { immediate: true });
+```
 
 ```js
-aa('onUserTokenChange', callback, { immediate: true });
+aa('init', { ... });
+aa('setUserToken', 'my-user-id-1');
+
+aa('onUserTokenChange', (userToken) => {
+  console.log(userToken); // prints out 'my-user-id-1'
+}, { immediate: true })
 ```
+
+With `immediate: true`, `onUserTokenChange` will be immediately fired with the token which is set beforehand.
 
 #### Report a click event
 

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -147,7 +147,7 @@ describe("init", () => {
       expect(analyticsInstance._userToken).toBeTruthy();
       expect(analyticsInstance._userToken.length).toBeGreaterThan(0);
       const callback = jest.fn();
-      analyticsInstance.onSetUserToken(callback, { immediate: true });
+      analyticsInstance.onUserTokenChange(callback, { immediate: true });
       expect(callback).toHaveBeenCalledWith(analyticsInstance._userToken);
       expect(callback).toHaveBeenCalledTimes(1);
 
@@ -163,7 +163,7 @@ describe("init", () => {
 
       analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
       const callback = jest.fn();
-      analyticsInstance.onSetUserToken(callback, { immediate: true });
+      analyticsInstance.onUserTokenChange(callback, { immediate: true });
       expect(callback).toHaveBeenCalledWith(undefined);
       expect(callback).toHaveBeenCalledTimes(1);
 

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -135,4 +135,42 @@ describe("init", () => {
     setUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+
+  describe("callback for userToken", () => {
+    it("should trigger callback when userToken is set with cookie support", () => {
+      const supportsCookies = jest
+        .spyOn(utils, "supportsCookies")
+        .mockReturnValue(true);
+
+      analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+      // Because cookie is enabled, anonymous token must be generated already.
+      expect(analyticsInstance._userToken).toBeTruthy();
+      expect(analyticsInstance._userToken.length).toBeGreaterThan(0);
+      const callback = jest.fn();
+      analyticsInstance.onSetUserToken(callback, { immediate: true });
+      expect(callback).toHaveBeenCalledWith(analyticsInstance._userToken);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      analyticsInstance.setUserToken("abc");
+      expect(callback).toHaveBeenCalledWith("abc");
+      supportsCookies.mockRestore();
+    });
+
+    it("should trigger callback when userToken is set without cookie support", () => {
+      const supportsCookies = jest
+        .spyOn(utils, "supportsCookies")
+        .mockReturnValue(false);
+
+      analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+      const callback = jest.fn();
+      analyticsInstance.onSetUserToken(callback, { immediate: true });
+      expect(callback).toHaveBeenCalledWith(undefined);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      analyticsInstance.setUserToken("abc");
+      expect(callback).toHaveBeenCalledWith("abc");
+      expect(callback).toHaveBeenCalledTimes(2);
+      supportsCookies.mockRestore();
+    });
+  });
 });

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -48,6 +48,9 @@ export function setUserToken(userToken: string | number): void {
   } else {
     this._userToken = userToken;
   }
+  if (this._onSetUserTokenCallback) {
+    this._onSetUserTokenCallback(this._userToken);
+  }
 }
 
 export function getUserToken(
@@ -58,4 +61,14 @@ export function getUserToken(
     callback(null, this._userToken);
   }
   return this._userToken;
+}
+
+export function onSetUserToken(
+  callback: (userToken: string) => void,
+  options?: { immediate: boolean }
+): void {
+  this._onSetUserTokenCallback = callback;
+  if (options && options.immediate) {
+    this._onSetUserTokenCallback(this._userToken);
+  }
 }

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -48,8 +48,8 @@ export function setUserToken(userToken: string | number): void {
   } else {
     this._userToken = userToken;
   }
-  if (this._onSetUserTokenCallback) {
-    this._onSetUserTokenCallback(this._userToken);
+  if (this._onUserTokenChangeCallback) {
+    this._onUserTokenChangeCallback(this._userToken);
   }
 }
 
@@ -63,12 +63,12 @@ export function getUserToken(
   return this._userToken;
 }
 
-export function onSetUserToken(
+export function onUserTokenChange(
   callback: (userToken: string) => void,
   options?: { immediate: boolean }
 ): void {
-  this._onSetUserTokenCallback = callback;
+  this._onUserTokenChangeCallback = callback;
   if (options && options.immediate) {
-    this._onSetUserTokenCallback(this._userToken);
+    this._onUserTokenChangeCallback(this._userToken);
   }
 }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -38,7 +38,7 @@ import {
   ANONYMOUS_USER_TOKEN,
   getUserToken,
   setUserToken,
-  onSetUserToken
+  onUserTokenChange
 } from "./_cookieUtils";
 import { version } from "../package.json";
 
@@ -94,7 +94,7 @@ class AlgoliaAnalytics {
     options?: any,
     callback?: (err: any, userToken: string) => void
   ) => string;
-  public onSetUserToken: (
+  public onUserTokenChange: (
     callback: (userToken: string) => void,
     options: { immediate: boolean }
   ) => void;
@@ -130,7 +130,7 @@ class AlgoliaAnalytics {
     this.ANONYMOUS_USER_TOKEN = ANONYMOUS_USER_TOKEN;
     this.setUserToken = setUserToken.bind(this);
     this.getUserToken = getUserToken.bind(this);
-    this.onSetUserToken = onSetUserToken.bind(this);
+    this.onUserTokenChange = onUserTokenChange.bind(this);
 
     this.clickedObjectIDsAfterSearch = clickedObjectIDsAfterSearch.bind(this);
     this.clickedObjectIDs = clickedObjectIDs.bind(this);

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -37,7 +37,8 @@ import {
 import {
   ANONYMOUS_USER_TOKEN,
   getUserToken,
-  setUserToken
+  setUserToken,
+  onSetUserToken
 } from "./_cookieUtils";
 import { version } from "../package.json";
 
@@ -93,6 +94,10 @@ class AlgoliaAnalytics {
     options?: any,
     callback?: (err: any, userToken: string) => void
   ) => string;
+  public onSetUserToken: (
+    callback: (userToken: string) => void,
+    options: { immediate: boolean }
+  ) => void;
 
   public clickedObjectIDsAfterSearch: (
     params: InsightsSearchClickEvent
@@ -125,6 +130,7 @@ class AlgoliaAnalytics {
     this.ANONYMOUS_USER_TOKEN = ANONYMOUS_USER_TOKEN;
     this.setUserToken = setUserToken.bind(this);
     this.getUserToken = getUserToken.bind(this);
+    this.onSetUserToken = onSetUserToken.bind(this);
 
     this.clickedObjectIDsAfterSearch = clickedObjectIDsAfterSearch.bind(this);
     this.clickedObjectIDs = clickedObjectIDs.bind(this);


### PR DESCRIPTION
This PR adds `onUserTokenChange` so that you can attach a callback to receive user token changes.