### PR TITLE
fix: return value from getUserToken

### DIFF
--- a/lib/__tests__/node.test.ts
+++ b/lib/__tests__/node.test.ts
@@ -1,0 +1,15 @@
+import insightsClient from "../node";
+
+describe("node", () => {
+  it("correctly return userToken", done => {
+    insightsClient("init", { appId: "xxx", apiKey: "***" });
+    insightsClient("setUserToken", "abc");
+    expect(insightsClient("getUserToken")).toEqual("abc");
+
+    insightsClient("setUserToken", "def");
+    insightsClient("getUserToken", null, (err, token) => {
+      expect(token).toEqual("def");
+      done();
+    });
+  });
+});

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -56,6 +56,7 @@ export function getUserToken(
 ): string {
   if (isFunction(callback)) {
     callback(null, this._userToken);
+    return;
   }
   return this._userToken;
 }

--- a/lib/_getFunctionalInterface.ts
+++ b/lib/_getFunctionalInterface.ts
@@ -4,7 +4,7 @@ import AlgoliaAnalytics from "./insights";
 export function getFunctionalInterface(instance: AlgoliaAnalytics) {
   return (functionName: string, ...functionArguments: any[]) => {
     if (functionName && isFunction((instance as any)[functionName])) {
-      instance[functionName](...functionArguments);
+      return instance[functionName](...functionArguments);
     }
   };
 }


### PR DESCRIPTION
This PR fixes the regression where it didn't return value from `getUserToken` correctly when it was used without callback.

Usage1. `aa("getUserToken", options, callback)` <- worked

Usage2. `const token = aa("getUserToken")` <- didn't worked. Fixed in this PR.


A working example: https://codesandbox.io/s/vanilla-dm9d7?file=/src/index.js