### PR TITLE
docs: add usage of createInsightsClient for node env

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,42 @@ aa('clickedObjectIDs', {
 });
 ```
 
+#### Customize the client
+
+If you want to customize the way to send events, you can create a custom Insights client.
+
+```js
+const { createInsightsClient } = require("search-insights");
+
+function requestFn(url, data) {
+  const serializedData = JSON.stringify(data);
+  const { protocol, host, path } = require("url").parse(url);
+  const options = {
+    protocol,
+    host,
+    path,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": serializedData.length
+    }
+  };
+
+  const { request: nodeRequest } =
+    url.indexOf("https://") === 0 ? require("https") : require("http");
+  const req = nodeRequest(options);
+
+  req.on("error", error => {
+    console.error(error);
+  });
+
+  req.write(serializedData);
+  req.end();
+};
+
+const aa = createInsightsClient(requestFn);
+```
+
 ## Use cases
 
 The Search Insights library supports both [Search](https://www.algolia.com/doc/guides/getting-insights-and-analytics/search-analytics/out-of-the-box-analytics/) and [Personalization](https://www.algolia.com/doc/guides/getting-insights-and-analytics/personalization/personalization/) Algolia features.


### PR DESCRIPTION
This PR adds the usage of `createInsightsClient` for node env.