### PR TITLE
feat(browser): expose createInsightsClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ aa('clickedObjectIDs', {
 If you want to customize the way to send events, you can create a custom Insights client.
 
 ```js
+// via ESM
+import { createInsightsClient } from "search-insights";
+// OR in commonJS
 const { createInsightsClient } = require("search-insights");
+// OR via the UMD
+const createInsightsClient = window.AlgoliaAnalytics.createInsightsClient;
 
 function requestFn(url, data) {
   const serializedData = JSON.stringify(data);

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -1,12 +1,14 @@
 import AlgoliaAnalytics from "./insights";
 import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { processQueue } from "./_processQueue";
+import { RequestFnType } from "./utils/request";
 
-const requestFn = getRequesterForBrowser();
-const instance = new AlgoliaAnalytics({ requestFn });
-if (typeof window !== "undefined") {
-  // Process queue upon script execution
-  processQueue.call(instance, window);
+export function createInsightsClient(requestFn: RequestFnType) {
+  const instance = new AlgoliaAnalytics({ requestFn });
+  if (typeof window !== "undefined") {
+    // Process queue upon script execution
+    processQueue.call(instance, window);
+  }
 }
 
-export default instance;
+export default createInsightsClient(getRequesterForBrowser());

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -1,8 +1,9 @@
 import AlgoliaAnalytics from "./insights";
 import { getFunctionalInterface } from "./_getFunctionalInterface";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
+import { RequestFnType } from "./utils/request";
 
-export function createInsightsClient(requestFn) {
+export function createInsightsClient(requestFn: RequestFnType) {
   return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));
 }
 


### PR DESCRIPTION
This was made in parallel to the node implementation

@eunjae-lee, do you know why the `getFunctionalInterface` isn't used in the browser?