### PR TITLE
docs(readme): update link to GTM custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Search Insights lets you report click, conversion and view metrics using the [Al
 ## Getting started
 
 
-> Are you using Google Tag Manager in your app? We provide a [custom template](gtm) to ease the integration.
+> Are you using Google Tag Manager in your app? We provide a [custom template](https://github.com/algolia/search-insights-gtm) to ease the integration.
 
 
 ### Browser


### PR DESCRIPTION
We moved the GTM integration to its own repo but the link wasn't updated.