### PR TITLE
fix(bundle): return instance from browser bundle and fix e2e test

### DIFF
--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -165,7 +165,8 @@ describe("Integration tests", () => {
       let objectIDs;
       beforeAll(async () => {
         await page.evaluate(() => {
-          window.AlgoliaAnalytics.default._endpointOrigin = "http://localhost:8080";
+          window.AlgoliaAnalytics.default._endpointOrigin =
+            "http://localhost:8080";
         });
         const event = await captureNetworkWhile(async () => {
           const button = await page.$(

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -165,7 +165,7 @@ describe("Integration tests", () => {
       let objectIDs;
       beforeAll(async () => {
         await page.evaluate(() => {
-          window.AlgoliaAnalytics._endpointOrigin = "http://localhost:8080";
+          window.AlgoliaAnalytics.default._endpointOrigin = "http://localhost:8080";
         });
         const event = await captureNetworkWhile(async () => {
           const button = await page.$(

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -9,6 +9,7 @@ export function createInsightsClient(requestFn: RequestFnType) {
     // Process queue upon script execution
     processQueue.call(instance, window);
   }
+  return instance;
 }
 
 export default createInsightsClient(getRequesterForBrowser());


### PR DESCRIPTION
This PR fixes the browser bundle. 

1. It didn't return `instance`
2. Now it's exporting the mix of default and named variables, so we need to use `window.AlgoliaAnalytics.default` instead of `window.AlgoliaAnalytics` in the e2e test.

On the user-side, they don't need to care about `.default` because all they use is `window.aa` which is created by the snippet:

```html
<script>
var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@1.4.0";

!function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
}(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
</script>
```

and when the library is loaded, when `instance` is created, it will run `processQueue` and it will replace `window.aa.queue`. User will keep using `window.aa`, so no problem on that side.