### PR TITLE
feat(get): add _get function

### DIFF
--- a/lib/__tests__/get.test.ts
+++ b/lib/__tests__/get.test.ts
@@ -1,0 +1,18 @@
+import AlgoliaAnalytics from "../insights";
+
+describe("get", () => {
+  let analyticsInstance;
+  beforeEach(() => {
+    analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
+  });
+
+  it("should get values from instance after init", () => {
+    const callback = jest.fn();
+    analyticsInstance.init({
+      appId: "xxx",
+      apiKey: "***",
+      region: "us"
+    });
+    analyticsInstance._get("appId", callback);
+  });
+});

--- a/lib/__tests__/get.test.ts
+++ b/lib/__tests__/get.test.ts
@@ -13,6 +13,20 @@ describe("get", () => {
       apiKey: "***",
       region: "us"
     });
-    analyticsInstance._get("appId", callback);
+    analyticsInstance._get("_appId", callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("xxx");
+
+    analyticsInstance._get("_apiKey", callback);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith("***");
+
+    analyticsInstance._get("_region", callback);
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenCalledWith("us");
+
+    analyticsInstance._get("_hasCredentials", callback);
+    expect(callback).toHaveBeenCalledTimes(4);
+    expect(callback).toHaveBeenCalledWith(true);
   });
 });

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -124,6 +124,7 @@ describe("Integration tests", () => {
       it("should retrieve a queryID on page load", async () => {
         expect(data).toHaveProperty("queryID");
       });
+
       it("should generate an anonymous userToken on init and store it in a cookie", async () => {
         const userToken = await page.evaluate(
           () =>
@@ -156,6 +157,18 @@ describe("Integration tests", () => {
             })
         );
         expect(userToken).toEqual("user-id-1");
+      });
+
+      it("should get _hasCredentials from the instance", async () => {
+        const hasCredentials = await page.evaluate(
+          () =>
+            new Promise((resolve, reject) => {
+              window.aa("_get", "_hasCredentials", hasCredentials => {
+                resolve(hasCredentials);
+              });
+            })
+        );
+        expect(hasCredentials).toBe(true);
       });
     });
 

--- a/lib/get.ts
+++ b/lib/get.ts
@@ -1,0 +1,5 @@
+export type GetCallback = (value: any) => void;
+
+export function get(key: string, callback: GetCallback) {
+  callback(this[key]);
+}

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -7,6 +7,7 @@ objectAssignPolyfill();
 import { makeSendEvent, InsightsEventType, InsightsEvent } from "./_sendEvent";
 
 import { InitParams, init } from "./init";
+import { get, GetCallback } from "./get";
 import { initSearch, InitSearchParams } from "./_initSearch";
 import { addAlgoliaAgent } from "./_algoliaAgent";
 
@@ -112,6 +113,8 @@ class AlgoliaAnalytics {
   public viewedObjectIDs: (params: InsightsSearchViewObjectIDsEvent) => void;
   public viewedFilters: (params: InsightsSearchViewFiltersEvent) => void;
 
+  public _get: (key: string, callback: GetCallback) => void;
+
   constructor({ requestFn }: { requestFn: RequestFnType }) {
     // Bind private methods to `this` class
     this.sendEvent = makeSendEvent(requestFn).bind(this);
@@ -138,6 +141,8 @@ class AlgoliaAnalytics {
 
     this.viewedObjectIDs = viewedObjectIDs.bind(this);
     this.viewedFilters = viewedFilters.bind(this);
+
+    this._get = get.bind(this);
   }
 }
 


### PR DESCRIPTION
This PR adds a method `_get` for internal usage.

Currently we cannot get the instance variables because the main interface is a function (`aa()`).
The initial reason for this functionality is because I need access to `_hasCredentials`.

The reason why I didn't make this function return a value, but make it accept a callback is,
it won't work in umd build.

```js
!function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
}(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
```

According to the snippet,

`window.aa` is basically a function adding commands to the queue.

```js
function () {
  (e[s].queue = e[s].queue || []).push(arguments);
}
```

In order to have the same signature across the browser and node env, I've decided to pass the callback function.