### PR TITLE
fix(userToken): let user clear the callback for userToken

### DIFF
--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -189,5 +189,29 @@ describe("init", () => {
         expect(callback).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe("nullish or invalid callback", () => {
+      it("should not throw an exception when setting nullish callback", () => {
+        analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+        analyticsInstance.setUserToken("abc");
+
+        expect(() => {
+          analyticsInstance.onUserTokenChange(undefined);
+        }).not.toThrow();
+
+        expect(() => {
+          analyticsInstance.onUserTokenChange(undefined, { immediate: true });
+        }).not.toThrow();
+      });
+
+      it("should not throw an exception when setting user token after setting invalid callback", () => {
+        analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+        analyticsInstance.onUserTokenChange("this is not a function");
+
+        expect(() => {
+          analyticsInstance.setUserToken("abc");
+        }).not.toThrow();
+      });
+    });
   });
 });

--- a/lib/_cookieUtils.ts
+++ b/lib/_cookieUtils.ts
@@ -48,7 +48,7 @@ export function setUserToken(userToken: string | number): void {
   } else {
     this._userToken = userToken;
   }
-  if (this._onUserTokenChangeCallback) {
+  if (isFunction(this._onUserTokenChangeCallback)) {
     this._onUserTokenChangeCallback(this._userToken);
   }
 }
@@ -68,7 +68,11 @@ export function onUserTokenChange(
   options?: { immediate: boolean }
 ): void {
   this._onUserTokenChangeCallback = callback;
-  if (options && options.immediate) {
+  if (
+    options &&
+    options.immediate &&
+    isFunction(this._onUserTokenChangeCallback)
+  ) {
     this._onUserTokenChangeCallback(this._userToken);
   }
 }


### PR DESCRIPTION
This PR updates `onUserTokenChange` so that when it receives `undefined`, then it can clear the previous callback and won't throw any exceptions.

Before this, the following code threw an exception:

```js
analyticsInstance.onUserTokenChange(undefined, { immediate: true });
```