### PR TITLE
feat(react-native): shim native node modules

### DIFF
--- a/empty-module.cjs.js
+++ b/empty-module.cjs.js
@@ -1,0 +1,3 @@
+// shim for node modules in React Native
+// see https://github.com/facebook/react-native/issues/5079
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "1.5.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "dist/search-insights.cjs.min.js",
+  "react-native": {
+    "http": "./empty-module.cjs.js",
+    "https": "./empty-module.cjs.js"
+  },
   "engines": {
     "node": ">=8.16.0"
   },


### PR DESCRIPTION
React Native's packager (Metro) will parse all files for dependencies, and will throw an error for missing dependencies, even if they are not used or in a try-catch

see: https://github.com/facebook/react-native/issues/5079