### PR TITLE
fix: do not store anonymous token in cookie when user has opted out

### DIFF
--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -1,10 +1,12 @@
 import AlgoliaAnalytics from "../insights";
 import * as utils from "../utils";
+import { getCookie } from "../_cookieUtils";
 
 describe("init", () => {
   let analyticsInstance;
   beforeEach(() => {
     analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
+    document.cookie = `_ALGOLIA=;${new Date().toUTCString()};path=/`;
   });
 
   it("should throw if no parameters is passed", () => {
@@ -62,6 +64,15 @@ describe("init", () => {
       userHasOptedOut: true
     });
     expect(analyticsInstance._userHasOptedOut).toBe(true);
+  });
+  it("should not set anonymous user token when _userHasOptedOut is true", () => {
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      userHasOptedOut: true
+    });
+    expect(analyticsInstance._userToken).toBeUndefined();
+    expect(getCookie("_ALGOLIA")).toBe("");
   });
   it("should use 6 months cookieDuration by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -72,7 +72,7 @@ export function init(options: InitParams) {
   this._ua = DEFAULT_ALGOLIA_AGENT;
   this._uaURIEncoded = encodeURIComponent(DEFAULT_ALGOLIA_AGENT);
 
-  if (supportsCookies()) {
+  if (!this._userHasOptedOut && supportsCookies()) {
     this.setUserToken(this.ANONYMOUS_USER_TOKEN);
   }
 }


### PR DESCRIPTION
## Summary

This PR follows `userHasOptedOut` a step further.
Even with `userHasOptedOut: true`, search-insights created anonymous user token and stored it in the cookie, which is totally not used at all. (I'm not talking about the possibility of that customers could've read that cookie directly for some reason)

In my opinion, this shouldn't be treated as a breaking change. What do you think?

---

ps. I put the people I recently talked about this with as reviewers.