### PR TITLE
fix: warn about unknown function name

### DIFF
--- a/lib/__tests__/_getFunctionalInterface.test.ts
+++ b/lib/__tests__/_getFunctionalInterface.test.ts
@@ -1,0 +1,20 @@
+import AlgoliaAnalytics from "../insights";
+import { getFunctionalInterface } from "../_getFunctionalInterface";
+
+describe("_getFunctionalInterface", () => {
+  let aa;
+
+  beforeEach(() => {
+    const analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
+    aa = getFunctionalInterface(analyticsInstance);
+  });
+
+  it("warn about unknown function name", () => {
+    console.warn = jest.fn();
+    aa("unknown-function");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "The method `unknown-function` doesn't exist."
+    );
+  });
+});

--- a/lib/_getFunctionalInterface.ts
+++ b/lib/_getFunctionalInterface.ts
@@ -5,6 +5,8 @@ export function getFunctionalInterface(instance: AlgoliaAnalytics) {
   return (functionName: string, ...functionArguments: any[]) => {
     if (functionName && isFunction((instance as any)[functionName])) {
       instance[functionName](...functionArguments);
+    } else {
+      console.warn(`The method \`${functionName}\` doesn't exist.`);
     }
   };
 }


### PR DESCRIPTION
## Summary

This PR adds a warning message about unknown function name. It used to just ignore unknown function names, which made it hard to notice when mistakes were made.