### PR TITLE
feat(init): accept userToken at init() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ aa('setUserToken', 'USER_ID');
 | `region`          | `'de' \| 'us'` | Automatic                | The DNS server to target                       |
 | `useCookie`       | `boolean`      | `true`                   | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
 | `cookieDuration`  | `number`       | `15552000000` (6 months) | The cookie duration in milliseconds            |
+| `userToken`       | `string`       | `undefined` (optional)   | Initial userToken. When given, anonymous userToken will not be set. |
 
 ### Node.js
 

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -294,5 +294,16 @@ describe("init", () => {
 
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
+
+    it("can set userToken manually afterwards", done => {
+      analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
+      analyticsInstance.setUserToken("def");
+      expect(setUserToken).toHaveBeenCalledTimes(2);
+      expect(setUserToken).toHaveBeenLastCalledWith("def");
+      analyticsInstance._get("_userToken", value => {
+        expect(value).toEqual("def");
+        done();
+      });
+    });
   });
 });

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -259,4 +259,40 @@ describe("init", () => {
       });
     });
   });
+
+  describe("userToken param", () => {
+    let setUserToken;
+    let setAnonymousUserToken;
+    beforeEach(() => {
+      setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
+      setAnonymousUserToken = jest.spyOn(
+        analyticsInstance,
+        "setAnonymousUserToken"
+      );
+    });
+
+    afterEach(() => {
+      setUserToken.mockRestore();
+      setAnonymousUserToken.mockRestore();
+    });
+
+    it("should set userToken", () => {
+      analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
+      expect(setUserToken).toHaveBeenCalledTimes(1);
+      expect(setUserToken).toHaveBeenCalledWith("abc");
+    });
+
+    it("shouldn't set anonymous user token to cookie", () => {
+      analyticsInstance.init({
+        apiKey: "***",
+        appId: "XXX",
+        userToken: "abc",
+        useCookie: true
+      });
+      expect(setUserToken).toHaveBeenCalledTimes(1);
+      expect(setUserToken).toHaveBeenCalledWith("abc");
+
+      expect(setAnonymousUserToken).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -12,6 +12,7 @@ export interface InitParams {
   useCookie?: boolean;
   cookieDuration?: number;
   region?: InsightRegion;
+  userToken?: string;
 }
 
 /**
@@ -73,7 +74,9 @@ export function init(options: InitParams) {
   this._ua = DEFAULT_ALGOLIA_AGENT;
   this._uaURIEncoded = encodeURIComponent(DEFAULT_ALGOLIA_AGENT);
 
-  if (!this._userHasOptedOut && this._useCookie) {
+  if (options.userToken) {
+    this.setUserToken(options.userToken);
+  } else if (!this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
   }
 }


### PR DESCRIPTION
This PR makes it accept `userToken` parameter at `init()` method, which enables users to initialize the insights client with the initial user token.

If it's given, it will not set anonymous user token in the cookie.

related: https://github.com/algolia/instantsearch.js/pull/4608