### PR TITLE
fix(types): emit and publish type definitions to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/screenshots
 tests/production
 tests/data.txt
 .env
+.idea

--- a/empty-module.cjs.d.ts
+++ b/empty-module.cjs.d.ts
@@ -1,0 +1,4 @@
+// shim for node modules in React Native
+// see https://github.com/facebook/react-native/issues/5079
+type empty = {};
+export default empty;

--- a/index-browser.cjs.d.ts
+++ b/index-browser.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/entry-browser-cjs";

--- a/index-node.cjs.d.ts
+++ b/index-node.cjs.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/entry-node-cjs";

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "*/package.json";

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.7.0",
   "jsdelivr": "dist/search-insights.min.js",
   "main": "index-node.cjs.js",
+  "types": "index-node.cjs.d.ts",
   "browser": "index-browser.cjs.js",
   "react-native": {
     "http": "./empty-module.cjs.js",
@@ -16,11 +17,13 @@
     "dist",
     "lib",
     "!**/__tests__/**",
-    "index.cjs.js",
-    "empty-module.cjs.js"
+    "empty-module.cjs.js",
+    "empty-module.cjs.d.ts",
+    "index-browser.cjs.d.ts",
+    "index-node.cjs.d.ts"
   ],
   "scripts": {
-    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js",
+    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js && tsc",
     "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
     "build:examples": "webpack --config config/webpack.config.js --color --progress",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "index-node.cjs.d.ts"
   ],
   "scripts": {
-    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js && tsc",
+    "build": "rollup --environment NODE_ENV:'production' -c rollup.config.js && tsc --build tsconfig.declaration.json",
     "build:dev": "rollup --watch --environment NODE_ENV:'development' -c rollup.config.js",
     "build:examples": "webpack --config config/webpack.config.js --color --progress",
     "dev": "NODE_ENV=development webpack --config config/webpack.config.js --color --progress --watch & node server/server",

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "./dist"
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,25 @@
 {
   "compilerOptions": {
-    "resolveJsonModule": true,
+    "resolveJsonModule": false,
     "moduleResolution": "node",
-    "noEmit": true,
     "noUnusedLocals": true,
-    "outDir": "./dist/",
+    "outDir": "./dist",
+    "rootDir": "./lib",
     "module": "es6",
     "target": "es6",
     "strict": true,
     "noImplicitThis": false,
     "strictNullChecks": false,
     "noImplicitAny": false,
-    "allowJs": true
+    "allowJs": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "emitDeclarationOnly": true
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "files": [
+    "./lib/typings.d.ts",
+    "./lib/entry-umd.ts",
+    "./lib/entry-node-cjs.ts",
+    "./lib/entry-browser-cjs.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "resolveJsonModule": false,
     "moduleResolution": "node",
+    "noEmit": true,
     "noUnusedLocals": true,
     "outDir": "./dist",
     "rootDir": "./lib",
@@ -11,10 +12,7 @@
     "noImplicitThis": false,
     "strictNullChecks": false,
     "noImplicitAny": false,
-    "allowJs": true,
-    "declaration": true,
-    "declarationDir": "./dist",
-    "emitDeclarationOnly": true
+    "allowJs": true
   },
   "files": [
     "./lib/typings.d.ts",


### PR DESCRIPTION
Related to this issue: https://github.com/algolia/search-insights.js/issues/9

- Type definitions are now emitted to the `./dist` folder using `tsc`.
- Types are now included in the tarball when running `npm publish` or `npm pack`.
