### PR TITLE
Explicitly export default

### DIFF
--- a/index-node.cjs.d.ts
+++ b/index-node.cjs.d.ts
@@ -1,1 +1,2 @@
 export * from "./dist/entry-node-cjs";
+export { default } from "./dist/entry-node-cjs";


### PR DESCRIPTION
**Summary**: `index-node.cjs.d.ts` does not have a default export, making the [usage in the docs](https://github.com/microsoft/TypeScript/issues/2726) throw type error import has no call signature. Reexport the default
**Problem**: file `index-node.cjs.d.ts` simply `export *` from file `./dist/entry-node-cjs`. `entry-node-cjs.d.ts` have a default export but `export *` does not let the default export flow through as described by [TypeScript issue 2726](https://github.com/microsoft/TypeScript/issues/2726)
```javascript
window.aa('init', {})
          ^^^^^^^^^^^
// this gives a type error as the library doesn't have a default export and therefore no callable signature
// however the code still runs 
```
**Solution**: explicitly reexport the default