### PR TITLE
fix(cookie): make useCookie false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Search Insights lets you report click, conversion and view metrics using the [Al
 
 <!-- tocstop -->
 
+## Notice on the cookie usage
+
+You're looking at the documentation of `search-insights` v2, which is the new major version.
+
+v2 introduces a breaking change which is `useCookie` being `false` by default. If it's `false`, `search-insights` doesn't generate anonymous userToken. It means no event will be sent until `setUserToken` is explicitly called.
+
 ## Getting started
 
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ aa('setUserToken', 'USER_ID');
 | **`apiKey`**      | `string`       | None (required)          | The search API key of your Algolia application |
 | `userHasOptedOut` | `boolean`      | `false`                  | Whether to exclude users from analytics        |
 | `region`          | `'de' \| 'us'` | Automatic                | The DNS server to target                       |
-| `useCookie`       | `boolean`      | `true`                   | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
+| `useCookie`       | `boolean`      | `false`                  | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
 | `cookieDuration`  | `number`       | `15552000000` (6 months) | The cookie duration in milliseconds            |
 | `userToken`       | `string`       | `undefined` (optional)   | Initial userToken. When given, anonymous userToken will not be set. |
 

--- a/examples/instantsearch/instantsearch.html
+++ b/examples/instantsearch/instantsearch.html
@@ -22,6 +22,7 @@
         apiKey: "@@API_KEY",
         appId: "@@APP_ID",
         region: "us",
+        useCookie: true,
         cookieDuration: 10 * 24 * 60 * 60 * 1000 // 10 days
       });
     </script>

--- a/examples/instantsearch/product.html
+++ b/examples/instantsearch/product.html
@@ -16,7 +16,8 @@
 
       aa("init", {
         apiKey: "@@API_KEY",
-        applicationID: "@@APP_ID"
+        applicationID: "@@APP_ID",
+        useCookie: true
       });
     </script>
   </head>

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -60,7 +60,8 @@ describe("Library initialisation", () => {
   it("Should create UUID", () => {
     analyticsInstance.init({
       apiKey: "1234",
-      appId: "ABCD"
+      appId: "ABCD",
+      useCookie: true
     });
     expect(analyticsInstance._userToken).not.toBeUndefined();
   });
@@ -114,10 +115,15 @@ describe("Integration tests", () => {
   describe("instantsearch example", () => {
     let data;
     beforeAll(async () => {
+      console.log("hey1");
       await page.goto(examplePath("instantsearch"));
+      console.log("hey2");
       await page.waitFor(1000);
+      console.log("hey3");
       data = await getPageResponse();
+      console.log("hey4");
       await page.waitFor(1000);
+      console.log("hey5");
     });
 
     describe("loading", () => {
@@ -177,10 +183,12 @@ describe("Integration tests", () => {
       let payload;
       let objectIDs;
       beforeAll(async () => {
+        console.log("here1");
         await page.evaluate(() => {
           window.AlgoliaAnalytics.default._endpointOrigin =
             "http://localhost:8080";
         });
+        console.log("here2");
         const event = await captureNetworkWhile(async () => {
           const button = await page.$(
             ".ais-hits--item:nth-child(2) .button-click"
@@ -191,6 +199,7 @@ describe("Integration tests", () => {
             button
           );
         });
+        console.log("here3");
         request = event.request;
         payload = event.payload;
       });

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -115,15 +115,10 @@ describe("Integration tests", () => {
   describe("instantsearch example", () => {
     let data;
     beforeAll(async () => {
-      console.log("hey1");
       await page.goto(examplePath("instantsearch"));
-      console.log("hey2");
       await page.waitFor(1000);
-      console.log("hey3");
       data = await getPageResponse();
-      console.log("hey4");
       await page.waitFor(1000);
-      console.log("hey5");
     });
 
     describe("loading", () => {
@@ -183,12 +178,10 @@ describe("Integration tests", () => {
       let payload;
       let objectIDs;
       beforeAll(async () => {
-        console.log("here1");
         await page.evaluate(() => {
           window.AlgoliaAnalytics.default._endpointOrigin =
             "http://localhost:8080";
         });
-        console.log("here2");
         const event = await captureNetworkWhile(async () => {
           const button = await page.$(
             ".ais-hits--item:nth-child(2) .button-click"
@@ -199,7 +192,6 @@ describe("Integration tests", () => {
             button
           );
         });
-        console.log("here3");
         request = event.request;
         payload = event.payload;
       });

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -179,7 +179,12 @@ describe("init", () => {
           .spyOn(utils, "supportsCookies")
           .mockReturnValue(true);
 
-        analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de", useCookie: true });
+        analyticsInstance.init({
+          apiKey: "***",
+          appId: "XXX",
+          region: "de",
+          useCookie: true
+        });
         // Because cookie is enabled, anonymous token must be generated already.
         expect(analyticsInstance._userToken).toBeTruthy();
         expect(analyticsInstance._userToken.length).toBeGreaterThan(0);

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -128,7 +128,12 @@ describe("init", () => {
       "setAnonymousUserToken"
     );
 
-    analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      region: "de",
+      useCookie: true
+    });
     expect(setAnonymousUserToken).toHaveBeenCalledTimes(1);
 
     setAnonymousUserToken.mockRestore();
@@ -174,7 +179,7 @@ describe("init", () => {
           .spyOn(utils, "supportsCookies")
           .mockReturnValue(true);
 
-        analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
+        analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de", useCookie: true });
         // Because cookie is enabled, anonymous token must be generated already.
         expect(analyticsInstance._userToken).toBeTruthy();
         expect(analyticsInstance._userToken.length).toBeGreaterThan(0);

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -63,7 +63,7 @@ export function init(options: InitParams) {
   this._endpointOrigin = options.region
     ? `https://insights.${options.region}.algolia.io`
     : "https://insights.algolia.io";
-  this._useCookie = options.useCookie ?? true;
+  this._useCookie = options.useCookie ?? false;
   this._cookieDuration = options.cookieDuration
     ? options.cookieDuration
     : 6 * MONTH;


### PR DESCRIPTION
## Sumary

This PR make `useCookie` `false` by default.

BREAKING CHANGE: It used to be `true`, but to be GDPR compliant, we're changing it to `false` by default.

For your information, this PR will be merged to `next` (not `master`).
Once it's ready to release the next major version, we will create a PR to merge `next` into `master`.