### PR TITLE
feat: add optional callback to event sending methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ aa('clickedObjectIDsAfterSearch', {
   queryID: getQueryID(),
   objectIDs: ['object1'],
   positions: [42],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                                                                         |
@@ -199,7 +201,9 @@ aa('convertedObjectIDsAfterSearch', {
   eventName: 'Add to basket',
   queryID: getQueryID(),
   objectIDs: ['object1'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                    |
@@ -288,7 +292,9 @@ aa('clickedObjectIDs', {
   index: 'INDEX_NAME',
   eventName: 'Add to basket',
   objectIDs: ['object1'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                    |
@@ -302,7 +308,9 @@ aa('clickedFilters', {
   index: 'INDEX_NAME',
   eventName: 'Filter on facet',
   filters: ['brand:Apple'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                                      |
@@ -318,7 +326,9 @@ aa('convertedObjectIDs', {
   index: 'INDEX_NAME',
   eventName: 'Add to basket',
   objectIDs: ['object1'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                    |
@@ -332,7 +342,9 @@ aa('convertedFilters', {
   index: 'INDEX_NAME',
   eventName: 'Filter on facet',
   filters: ['brand:Apple'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                                      |
@@ -348,7 +360,9 @@ aa('viewedObjectIDs', {
   index: 'INDEX_NAME',
   eventName: 'Add to basket',
   objectIDs: ['object1'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                    |
@@ -362,7 +376,9 @@ aa('viewedFilters', {
   index: 'INDEX_NAME',
   eventName: 'Filter on facet',
   filters: ['brand:Apple'],
-});
+}, callback);
+
+// callback?: (error, result) => void;
 ```
 
 | Option      | Type       | Description                                                      |

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -179,7 +179,8 @@ describe("sendEvent", () => {
               userToken: "mock-user-id"
             }
           ]
-        }
+        },
+        undefined
       );
     });
 

--- a/lib/__tests__/callback.test.ts
+++ b/lib/__tests__/callback.test.ts
@@ -160,8 +160,13 @@ describe("AlgoliaAnalytics - callback", () => {
       insightsClient._endpointOrigin = "https://not_existing_domain!!!.com";
       aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
         expect(result).toBeUndefined();
-        expect(error).toMatchInlineSnapshot(
-          `[Error: getaddrinfo ENOTFOUND not_existing_domain]`
+        expect(error).toEqual(
+          expect.objectContaining({
+            errno: "ENOTFOUND",
+            code: "ENOTFOUND",
+            syscall: "getaddrinfo",
+            hostname: "not_existing_domain"
+          })
         );
         done();
       });

--- a/lib/__tests__/callback.test.ts
+++ b/lib/__tests__/callback.test.ts
@@ -1,0 +1,170 @@
+import AlgoliaAnalytics from "../insights";
+import { getFunctionalInterface } from "../_getFunctionalInterface";
+import {
+  requestWithSendBeacon,
+  requestWithXMLHttpRequest,
+  requestWithNodeHttpModule
+} from "../utils/request";
+require("dotenv").config();
+
+const payload = {
+  eventType: "click",
+  eventName: "hit-clicked",
+  userToken: "user-id-1",
+  index: "instant_search",
+  queryID: "ebdfbbdd3fba888026416515c26d7954",
+  objectIDs: ["3828012"],
+  positions: [2]
+};
+
+describe("AlgoliaAnalytics - callback", () => {
+  describe("sendBeacon", () => {
+    beforeEach(() => {
+      navigator.sendBeacon = jest.fn();
+    });
+
+    it("calls the callback with no result", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithSendBeacon
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: process.env.APP_ID,
+        apiKey: process.env.API_KEY
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(error).toBeUndefined();
+        expect(result).toBeUndefined();
+        done();
+      });
+    });
+
+    it("calls the callback with no error from wrong credentials", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithSendBeacon
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: "wrong-app-id",
+        apiKey: "wrong-api-key"
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(result).toBeUndefined();
+        expect(error).toBeUndefined();
+        done();
+      });
+    });
+  });
+
+  describe("XMLHttpRequest", () => {
+    it("calls the callback with result", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithXMLHttpRequest
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: process.env.APP_ID,
+        apiKey: process.env.API_KEY
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(error).toBeNull();
+        expect(result).toEqual('{"status":200,"message":"OK"}');
+        done();
+      });
+    });
+
+    it("calls the callback with error from wrong credentials", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithXMLHttpRequest
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: "wrong-app-id",
+        apiKey: "wrong-api-key"
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(result).toBeUndefined();
+        expect(error).toEqual({
+          responseText: '{"status":401,"message":"Invalid credentials"}',
+          status: 401,
+          statusText: "Unauthorized"
+        });
+        done();
+      });
+    });
+
+    it("calls the callback with error from wrong endpoint", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithXMLHttpRequest
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: "wrong-app-id",
+        apiKey: "wrong-api-key"
+      });
+      insightsClient._endpointOrigin = "https://not_existing_domain!!!.com";
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(result).toBeUndefined();
+        expect(error).toEqual({ responseText: "", status: 0, statusText: "" });
+        done();
+      });
+    });
+  });
+
+  describe("node http/https", () => {
+    it("calls the callback with result", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithNodeHttpModule
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: process.env.APP_ID,
+        apiKey: process.env.API_KEY
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(error).toBeNull();
+        expect(result).toEqual('{"status":200,"message":"OK"}');
+        done();
+      });
+    });
+
+    it("calls the callback with error from wrong credentials", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithNodeHttpModule
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: "wrong-app-id",
+        apiKey: "wrong-api-key"
+      });
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(result).toBeUndefined();
+        expect(error).toEqual({
+          responseText: '{"status":401,"message":"Invalid credentials"}',
+          status: 401,
+          statusText: "Unauthorized"
+        });
+        done();
+      });
+    });
+
+    it("calls the callback with error from wrong endpoint", done => {
+      const insightsClient = new AlgoliaAnalytics({
+        requestFn: requestWithNodeHttpModule
+      });
+      const aa = getFunctionalInterface(insightsClient);
+      aa("init", {
+        appId: "wrong-app-id",
+        apiKey: "wrong-api-key"
+      });
+      insightsClient._endpointOrigin = "https://not_existing_domain!!!.com";
+      aa("clickedObjectIDsAfterSearch", payload, (error, result) => {
+        expect(result).toBeUndefined();
+        expect(error).toMatchInlineSnapshot(
+          `[Error: getaddrinfo ENOTFOUND not_existing_domain]`
+        );
+        done();
+      });
+    });
+  });
+});

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -69,7 +69,8 @@ describe("clickedObjectIDsAfterSearch", () => {
 
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "click",
-      clickParams
+      clickParams,
+      undefined
     );
   });
 });
@@ -102,7 +103,8 @@ describe("clickedObjectIDs", () => {
 
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "click",
-      clickParams
+      clickParams,
+      undefined
     );
   });
 });
@@ -135,7 +137,8 @@ describe("clickedFilters", () => {
 
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "click",
-      clickParams
+      clickParams,
+      undefined
     );
   });
 });

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -57,7 +57,8 @@ describe("convertedObjectIDsAfterSearch", () => {
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "conversion",
-      { objectIDs: ["12345"], queryID: "test" }
+      { objectIDs: ["12345"], queryID: "test" },
+      undefined
     );
   });
 });
@@ -98,7 +99,8 @@ describe("convertedObjectIDs", () => {
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "conversion",
-      { objectIDs: ["12345"] }
+      { objectIDs: ["12345"] },
+      undefined
     );
   });
 });
@@ -139,7 +141,8 @@ describe("convertedFilters", () => {
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
       "conversion",
-      { filters: ["brands:apple"] }
+      { filters: ["brands:apple"] },
+      undefined
     );
   });
 });

--- a/lib/__tests__/view.test.ts
+++ b/lib/__tests__/view.test.ts
@@ -38,9 +38,13 @@ describe("viewedObjectIDs", () => {
       objectIDs: ["12345"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith("view", {
-      objectIDs: ["12345"]
-    });
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
+      "view",
+      {
+        objectIDs: ["12345"]
+      },
+      undefined
+    );
   });
 });
 
@@ -78,8 +82,12 @@ describe("viewedFilters", () => {
       filters: ["brands:apple"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith("view", {
-      filters: ["brands:apple"]
-    });
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
+      "view",
+      {
+        filters: ["brands:apple"]
+      },
+      undefined
+    );
   });
 });

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,4 +1,5 @@
 import { InsightsEvent } from "./_sendEvent";
+import { RequestCallback } from "./utils/request";
 
 export interface InsightsSearchClickEvent {
   userToken?: string;
@@ -14,7 +15,10 @@ export interface InsightsSearchClickEvent {
  * Sends a click report in the context of search
  * @param params: InsightsSearchClickEvent
  */
-export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
+export function clickedObjectIDsAfterSearch(
+  params: InsightsSearchClickEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to clickedObjectIDsAfterSearch function, please provide `queryID`,  `objectIDs` and `positions` to be reported"
@@ -36,7 +40,7 @@ export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
     );
   }
 
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent("click", params as InsightsEvent, callback);
 }
 
 export interface InsightsClickObjectIDsEvent {
@@ -52,7 +56,10 @@ export interface InsightsClickObjectIDsEvent {
  * Sends a click report using objectIDs, outside the context of a search
  * @param params: InsightsClickObjectIDsEvent
  */
-export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
+export function clickedObjectIDs(
+  params: InsightsClickObjectIDsEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to clickedObjectIDs function, please provide `objectIDs` to be reported"
@@ -64,7 +71,7 @@ export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
     );
   }
 
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent("click", params as InsightsEvent, callback);
 }
 
 export interface InsightsClickFiltersEvent {
@@ -80,7 +87,10 @@ export interface InsightsClickFiltersEvent {
  * Sends a click report using filters
  * @param params: InsightsClickFiltersEvent
  */
-export function clickedFilters(params: InsightsClickFiltersEvent) {
+export function clickedFilters(
+  params: InsightsClickFiltersEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to clickedFilters function, please provide `filters` to be reported"
@@ -92,5 +102,5 @@ export function clickedFilters(params: InsightsClickFiltersEvent) {
     );
   }
 
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent("click", params as InsightsEvent, callback);
 }

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,4 +1,5 @@
 import { InsightsEvent } from "./_sendEvent";
+import { RequestCallback } from "./utils/request";
 
 export interface InsightsSearchConversionEvent {
   userToken?: string;
@@ -14,7 +15,8 @@ export interface InsightsSearchConversionEvent {
  * @param params InsightsSearchConversionEvent
  */
 export function convertedObjectIDsAfterSearch(
-  params: InsightsSearchConversionEvent
+  params: InsightsSearchConversionEvent,
+  callback?: RequestCallback
 ) {
   if (!params) {
     throw new Error(
@@ -32,7 +34,7 @@ export function convertedObjectIDsAfterSearch(
     );
   }
 
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent("conversion", params as InsightsEvent, callback);
 }
 
 export interface InsightsSearchConversionObjectIDsEvent {
@@ -48,7 +50,8 @@ export interface InsightsSearchConversionObjectIDsEvent {
  * @param params InsightsSearchConversionObjectIDsEvent
  */
 export function convertedObjectIDs(
-  params: InsightsSearchConversionObjectIDsEvent
+  params: InsightsSearchConversionObjectIDsEvent,
+  callback?: RequestCallback
 ) {
   if (!params) {
     throw new Error(
@@ -62,7 +65,7 @@ export function convertedObjectIDs(
     );
   }
 
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent("conversion", params as InsightsEvent, callback);
 }
 
 export interface InsightsSearchConversionFiltersEvent {
@@ -77,7 +80,10 @@ export interface InsightsSearchConversionFiltersEvent {
  * Sends a conversion report using filters, outside the context of a search
  * @param params InsightsSearchConversionFiltersEvent
  */
-export function convertedFilters(params: InsightsSearchConversionFiltersEvent) {
+export function convertedFilters(
+  params: InsightsSearchConversionFiltersEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to convertedFilters function, please provide `filters` to be reported"
@@ -89,5 +95,5 @@ export function convertedFilters(params: InsightsSearchConversionFiltersEvent) {
     );
   }
 
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent("conversion", params as InsightsEvent, callback);
 }

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -99,16 +99,19 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
-    expect(nodeHttpRequest).toHaveBeenLastCalledWith({
-      protocol: "http:",
-      host: "random.url",
-      path: "/",
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": JSON.stringify(data).length
-      }
-    });
+    expect(nodeHttpRequest).toHaveBeenLastCalledWith(
+      {
+        protocol: "http:",
+        host: "random.url",
+        path: "/",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": JSON.stringify(data).length
+        }
+      },
+      expect.any(Function)
+    );
     expect(nodeHttpRequest).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenLastCalledWith(JSON.stringify(data));
     expect(write).toHaveBeenCalledTimes(1);
@@ -126,16 +129,19 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
-    expect(nodeHttpsRequest).toHaveBeenLastCalledWith({
-      protocol: "https:",
-      host: "random.url",
-      path: "/",
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": JSON.stringify(data).length
-      }
-    });
+    expect(nodeHttpsRequest).toHaveBeenLastCalledWith(
+      {
+        protocol: "https:",
+        host: "random.url",
+        path: "/",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": JSON.stringify(data).length
+        }
+      },
+      expect.any(Function)
+    );
     expect(nodeHttpsRequest).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenLastCalledWith(JSON.stringify(data));
     expect(write).toHaveBeenCalledTimes(1);

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,18 +1,50 @@
-export type RequestFnType = (url: string, data: object) => void;
+export type RequestCallback = (error?: any, data?: any) => void;
+export type RequestFnType = (
+  url: string,
+  data: object,
+  callback?: RequestCallback
+) => void;
 
-export const requestWithSendBeacon: RequestFnType = (url, data) => {
+export const requestWithSendBeacon: RequestFnType = (url, data, callback) => {
   const serializedData = JSON.stringify(data);
   navigator.sendBeacon(url, serializedData);
+  if (callback) {
+    callback();
+  }
 };
 
-export const requestWithXMLHttpRequest: RequestFnType = (url, data) => {
+export const requestWithXMLHttpRequest: RequestFnType = (
+  url,
+  data,
+  callback
+) => {
   const serializedData = JSON.stringify(data);
-  const report = new XMLHttpRequest();
-  report.open("POST", url);
-  report.send(serializedData);
+  const xhr = new XMLHttpRequest();
+  if (callback) {
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        const status = xhr.status;
+        if (status >= 200 && status < 400) {
+          callback(null, xhr.responseText);
+        } else {
+          callback({
+            status: xhr.status,
+            statusText: xhr.statusText,
+            responseText: xhr.responseText
+          });
+        }
+      }
+    };
+  }
+  xhr.open("POST", url);
+  xhr.send(serializedData);
 };
 
-export const requestWithNodeHttpModule: RequestFnType = (url, data) => {
+export const requestWithNodeHttpModule: RequestFnType = (
+  url,
+  data,
+  callback
+) => {
   const serializedData = JSON.stringify(data);
   const { protocol, host, path } = require("url").parse(url);
   const options = {
@@ -28,12 +60,34 @@ export const requestWithNodeHttpModule: RequestFnType = (url, data) => {
 
   const { request: nodeRequest } =
     url.indexOf("https://") === 0 ? require("https") : require("http");
-  const req = nodeRequest(options);
-
-  req.on("error", error => {
-    console.error(error);
+  const req = nodeRequest(options, res => {
+    let responseText = "";
+    // We need to hook `data` event. If not, we won't get `end` event.
+    // https://stackoverflow.com/questions/23817180/node-js-response-from-http-request-not-calling-end-event-without-including-da
+    res.on("data", data => {
+      responseText += data;
+    });
+    res.on("end", () => {
+      if (!callback) {
+        return;
+      }
+      const { statusCode, statusMessage } = res;
+      if (statusCode >= 200 && statusCode < 400) {
+        callback(null, responseText);
+      } else {
+        callback({
+          responseText,
+          status: statusCode,
+          statusText: statusMessage
+        });
+      }
+    });
   });
-
+  req.on("error", error => {
+    if (callback) {
+      callback(error);
+    }
+  });
   req.write(serializedData);
   req.end();
 };

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -1,4 +1,5 @@
 import { InsightsEvent } from "./_sendEvent";
+import { RequestCallback } from "./utils/request";
 
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
@@ -12,7 +13,10 @@ export interface InsightsSearchViewObjectIDsEvent {
  * Sends a view report using objectIDs
  * @param params InsightsSearchViewObjectIDsEvent
  */
-export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
+export function viewedObjectIDs(
+  params: InsightsSearchViewObjectIDsEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to viewedObjectIDs function, please provide `objectIDs` to be reported"
@@ -24,7 +28,7 @@ export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
     );
   }
 
-  this.sendEvent("view", params as InsightsEvent);
+  this.sendEvent("view", params as InsightsEvent, callback);
 }
 
 export interface InsightsSearchViewFiltersEvent {
@@ -39,7 +43,10 @@ export interface InsightsSearchViewFiltersEvent {
  * Sends a view report using filters
  * @param params InsightsSearchViewFiltersEvent
  */
-export function viewedFilters(params: InsightsSearchViewFiltersEvent) {
+export function viewedFilters(
+  params: InsightsSearchViewFiltersEvent,
+  callback?: RequestCallback
+) {
   if (!params) {
     throw new Error(
       "No params were sent to viewedFilters function, please provide `filters` to be reported"
@@ -51,5 +58,5 @@ export function viewedFilters(params: InsightsSearchViewFiltersEvent) {
     );
   }
 
-  this.sendEvent("view", params as InsightsEvent);
+  this.sendEvent("view", params as InsightsEvent, callback);
 }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   "bundlesize": [
     {
       "path": "./dist/search-insights.min.js",
-      "maxSize": "3 kB"
+      "maxSize": "3.25 kB"
     }
   ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ const createPlugins = () => [
   }),
   buble(),
   commonjs(),
-  uglify(),
+  // uglify(),
   filesize()
 ];
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ const createPlugins = () => [
   }),
   buble(),
   commonjs(),
-  // uglify(),
+  uglify(),
   filesize()
 ];
 


### PR DESCRIPTION
## Summary

This PR adds an optional callback to event sending methods:

- viewedObjectIDs
- viewedFilters
- clickedObjectIDsAfterSearch
- clickedObjectIDs
- clickedFilters
- convertedObjectIDsAfterSearch
- convertedObjectIDs
- convertedFilters

Choosing a callback instead of returning a Promise is because the umd version works with a queue.

`aa(method)` doesn't call the actual function, but queues the method and later invokes it as soon as the library is loaded. That's why we can't return a Promise and use the callback pattern.