### PR TITLE
fix(userToken): prevent anonymous user token from overriding existing token

### DIFF
--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -166,6 +166,29 @@ describe("init", () => {
     setAnonymousUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+  it("should not set anonymous userToken if a token is already set", () => {
+    const setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX"
+    });
+    expect(setUserToken).toHaveBeenCalledTimes(1);
+    expect(setUserToken).toHaveBeenCalledWith(
+      expect.stringMatching(/^anonymous-/)
+    );
+
+    analyticsInstance.setUserToken("my-token");
+    expect(setUserToken).toHaveBeenCalledTimes(2);
+    expect(setUserToken).toHaveBeenLastCalledWith("my-token");
+
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX"
+    });
+    expect(setUserToken).toHaveBeenCalledTimes(2);
+
+    setUserToken.mockRestore();
+  });
 
   describe("callback for userToken", () => {
     describe("immediate: true", () => {

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -76,7 +76,7 @@ export function init(options: InitParams) {
 
   if (options.userToken) {
     this.setUserToken(options.userToken);
-  } else if (!this._userHasOptedOut && this._useCookie) {
+  } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
   }
 }


### PR DESCRIPTION
## Summary

This PR prevents anonymous user token overriding an existing token.

It happens only when `init()` is called multiple times.

```js
aa('init', { appId, apiKey }); // this sets anonymous user token
aa('setUserToken', 'my-token');

aa('init', { appId, apiKey }); // this sets anonymous user token again and overrides 'my-token'
```

This prevents the side effect of calling `init()` multiple times.

An alternative solution is to skip `init()` calls if it was already initialized, but I'm not sure if that's a correct behavior.