### PR TITLE
chore: export AlgoliaAnalytics

### DIFF
--- a/lib/entry-browser-cjs.ts
+++ b/lib/entry-browser-cjs.ts
@@ -2,13 +2,15 @@ import AlgoliaAnalytics from "./insights";
 import { getFunctionalInterface } from "./_getFunctionalInterface";
 import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
+import { processQueue } from "./_processQueue";
 import { RequestFnType } from "./utils/request";
 
 export {
+  getRequesterForBrowser,
+  getRequesterForNode,
   AlgoliaAnalytics,
   getFunctionalInterface,
-  getRequesterForBrowser,
-  getRequesterForNode
+  processQueue
 };
 
 export function createInsightsClient(requestFn: RequestFnType) {

--- a/lib/entry-browser-cjs.ts
+++ b/lib/entry-browser-cjs.ts
@@ -2,16 +2,9 @@ import AlgoliaAnalytics from "./insights";
 import { getFunctionalInterface } from "./_getFunctionalInterface";
 import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
-import { processQueue } from "./_processQueue";
 import { RequestFnType } from "./utils/request";
 
-export {
-  getRequesterForBrowser,
-  getRequesterForNode,
-  AlgoliaAnalytics,
-  getFunctionalInterface,
-  processQueue
-};
+export { getRequesterForBrowser, getRequesterForNode, AlgoliaAnalytics };
 
 export function createInsightsClient(requestFn: RequestFnType) {
   return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));

--- a/lib/entry-browser-cjs.ts
+++ b/lib/entry-browser-cjs.ts
@@ -4,7 +4,12 @@ import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
 import { RequestFnType } from "./utils/request";
 
-export { getRequesterForBrowser, getRequesterForNode };
+export {
+  AlgoliaAnalytics,
+  getFunctionalInterface,
+  getRequesterForBrowser,
+  getRequesterForNode
+};
 
 export function createInsightsClient(requestFn: RequestFnType) {
   return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));

--- a/lib/entry-node-cjs.ts
+++ b/lib/entry-node-cjs.ts
@@ -4,12 +4,7 @@ import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
 import { RequestFnType } from "./utils/request";
 
-export {
-  AlgoliaAnalytics,
-  getFunctionalInterface,
-  getRequesterForBrowser,
-  getRequesterForNode
-};
+export { getRequesterForBrowser, getRequesterForNode, AlgoliaAnalytics };
 
 export function createInsightsClient(requestFn: RequestFnType) {
   return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));

--- a/lib/entry-node-cjs.ts
+++ b/lib/entry-node-cjs.ts
@@ -4,7 +4,12 @@ import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
 import { RequestFnType } from "./utils/request";
 
-export { getRequesterForBrowser, getRequesterForNode };
+export {
+  AlgoliaAnalytics,
+  getFunctionalInterface,
+  getRequesterForBrowser,
+  getRequesterForNode
+};
 
 export function createInsightsClient(requestFn: RequestFnType) {
   return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));


### PR DESCRIPTION
This PR exports `AlgoliaAnalytics` to create insights client for those who want more control.
Before, it was only possible to choose which requester to use. 

This PR enables https://github.com/algolia/instantsearch.js/pull/4712