### PR TITLE
feat: add `ready()`

### DIFF
--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -16,10 +16,12 @@ const makeGlobalObject = () => {
 class FakeAlgoliaAnalytics {
   public init: Function;
   public otherMethod: Function;
+  public ready: Function;
   public processQueue: Function;
   constructor() {
     this.init = jest.fn();
     this.otherMethod = jest.fn(() => "otherMethodReturnedValue");
+    this.ready = jest.fn(callback => callback());
 
     this.processQueue = processQueue.bind(this); // the function we'll be testing
   }
@@ -73,5 +75,21 @@ describe("processQueue", () => {
     insights.processQueue(globalObject);
     const newPointerFunction = globalObject.aa;
     expect(oldPointerFunction).toBe(newPointerFunction);
+  });
+
+  it("should executes the callback as soon as ready", () => {
+    const callback = jest.fn();
+    globalObject.aa("init", { appID: "xxx", apiKey: "yyy" });
+    globalObject.aa("ready", callback);
+
+    expect(insights.init).not.toHaveBeenCalled();
+    expect(insights.ready).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(0);
+
+    insights.processQueue(globalObject);
+
+    expect(insights.init).toHaveBeenCalledWith({ appID: "xxx", apiKey: "yyy" });
+    expect(insights.ready).toHaveBeenCalledWith(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/__tests__/_processQueue.test.ts
+++ b/lib/__tests__/_processQueue.test.ts
@@ -77,7 +77,7 @@ describe("processQueue", () => {
     expect(oldPointerFunction).toBe(newPointerFunction);
   });
 
-  it("should executes the callback as soon as ready", () => {
+  it("should execute the callback as soon as ready", () => {
     const callback = jest.fn();
     globalObject.aa("init", { appID: "xxx", apiKey: "yyy" });
     globalObject.aa("ready", callback);

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -16,6 +16,7 @@ describe("init", () => {
       `"Init function should be called with an object argument containing your apiKey and appId"`
     );
   });
+
   it("should throw if apiKey is not sent", () => {
     expect(() => {
       (analyticsInstance as any).init({ appId: "***" });
@@ -23,6 +24,7 @@ describe("init", () => {
       `"apiKey is missing, please provide it so we can authenticate the application"`
     );
   });
+
   it("should throw if appId is not sent", () => {
     expect(() => {
       (analyticsInstance as any).init({ apiKey: "***" });
@@ -30,6 +32,7 @@ describe("init", () => {
       `"appId is missing, please provide it, so we can properly attribute data to your application"`
     );
   });
+
   it("should throw if region is other than `de` | `us`", () => {
     expect(() => {
       (analyticsInstance as any).init({
@@ -41,22 +44,27 @@ describe("init", () => {
       `"optional region is incorrect, please provide either one of: de, us."`
     );
   });
+
   it("should set _appId on instance", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     expect(analyticsInstance._appId).toBe("XXX");
   });
+
   it("should set _apiKey on instance", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     expect(analyticsInstance._apiKey).toBe("***");
   });
+
   it("should set _region on instance", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "us" });
     expect(analyticsInstance._region).toBe("us");
   });
+
   it("should set _userHasOptedOut on instance to false by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     expect(analyticsInstance._userHasOptedOut).toBe(false);
   });
+
   it("should set _userHasOptedOut on instance when passed", () => {
     analyticsInstance.init({
       apiKey: "***",
@@ -65,6 +73,7 @@ describe("init", () => {
     });
     expect(analyticsInstance._userHasOptedOut).toBe(true);
   });
+
   it("should not set anonymous user token when _userHasOptedOut is true", () => {
     analyticsInstance.init({
       apiKey: "***",
@@ -74,6 +83,7 @@ describe("init", () => {
     expect(analyticsInstance._userToken).toBeUndefined();
     expect(getCookie("_ALGOLIA")).toBe("");
   });
+
   it("should use 6 months cookieDuration by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     const month = 30 * 24 * 60 * 60 * 1000;
@@ -101,24 +111,28 @@ describe("init", () => {
     });
     expect(analyticsInstance._cookieDuration).toBe(42);
   });
+
   it("should set _endpointOrigin on instance to https://insights.algolia.io", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     expect(analyticsInstance._endpointOrigin).toBe(
       "https://insights.algolia.io"
     );
   });
+
   it("should set _endpointOrigin on instance to https://insights.us.algolia.io if region === 'us'", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "us" });
     expect(analyticsInstance._endpointOrigin).toBe(
       "https://insights.us.algolia.io"
     );
   });
+
   it("should set _endpointOrigin on instance to https://insights.de.algolia.io if region === 'de'", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "de" });
     expect(analyticsInstance._endpointOrigin).toBe(
       "https://insights.de.algolia.io"
     );
   });
+
   it("should set anonymous userToken if environment supports cookies", () => {
     const supportsCookies = jest
       .spyOn(utils, "supportsCookies")
@@ -134,6 +148,7 @@ describe("init", () => {
     setAnonymousUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+
   it("should not set anonymous userToken if environment does not supports cookies", () => {
     const supportsCookies = jest
       .spyOn(utils, "supportsCookies")
@@ -146,6 +161,7 @@ describe("init", () => {
     setUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+
   it("should not set anonymous userToken if useCookie is false", () => {
     const supportsCookies = jest
       .spyOn(utils, "supportsCookies")
@@ -166,6 +182,7 @@ describe("init", () => {
     setAnonymousUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+
   it("should not set anonymous userToken if a token is already set", () => {
     const setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
     analyticsInstance.init({

--- a/lib/__tests__/ready.test.ts
+++ b/lib/__tests__/ready.test.ts
@@ -1,7 +1,7 @@
 import AlgoliaAnalytics from "../insights";
 
 describe("ready()", () => {
-  it("Should execute the callback", () => {
+  it("should execute the callback", () => {
     const analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
     const callback = jest.fn();
     analyticsInstance.ready(callback);

--- a/lib/__tests__/ready.test.ts
+++ b/lib/__tests__/ready.test.ts
@@ -1,0 +1,10 @@
+import AlgoliaAnalytics from "../insights";
+
+describe("ready()", () => {
+  it("Should execute the callback", () => {
+    const analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
+    const callback = jest.fn();
+    analyticsInstance.ready(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -41,6 +41,7 @@ import {
   setAnonymousUserToken,
   onUserTokenChange
 } from "./_tokenUtils";
+import { ready } from "./ready";
 import { version } from "../package.json";
 
 type Queue = {
@@ -119,6 +120,8 @@ class AlgoliaAnalytics {
   public viewedObjectIDs: (params: InsightsSearchViewObjectIDsEvent) => void;
   public viewedFilters: (params: InsightsSearchViewFiltersEvent) => void;
 
+  public ready: (callback: Function) => void;
+
   public _get: (key: string, callback: GetCallback) => void;
 
   constructor({ requestFn }: { requestFn: RequestFnType }) {
@@ -148,6 +151,8 @@ class AlgoliaAnalytics {
 
     this.viewedObjectIDs = viewedObjectIDs.bind(this);
     this.viewedFilters = viewedFilters.bind(this);
+
+    this.ready = ready.bind(this);
 
     this._get = get.bind(this);
   }

--- a/lib/ready.ts
+++ b/lib/ready.ts
@@ -1,0 +1,5 @@
+export function ready(callback: Function) {
+  if (typeof callback === "function") {
+    callback();
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds `ready()` method.

## Details

It enables users to do things like the following:

```js
window.aa("ready", () => {
  console.log("The library is loaded.");
});
```

The name is inspired by jQuery's ready() and [Segment's ready()](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#ready).

When `search-insights` is inserted like the following:

```html
<script>
var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@1.7.1";

!function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
}(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
</script>
```

It's hard to figure out if the library is loaded, or `window.aa` is still just an array of pending queue.

With this addition, no matter CJS or UMD, we can act on it as soon as the library is ready.