### PR TITLE
fix(types): export default

### DIFF
--- a/index-browser.cjs.d.ts
+++ b/index-browser.cjs.d.ts
@@ -1,1 +1,3 @@
 export * from "./dist/entry-browser-cjs";
+import aa from "./dist/entry-browser-cjs";
+export default aa;

--- a/index-node.cjs.d.ts
+++ b/index-node.cjs.d.ts
@@ -1,2 +1,3 @@
 export * from "./dist/entry-node-cjs";
-export { default } from "./dist/entry-node-cjs";
+import aa from "./dist/entry-node-cjs";
+export default aa;


### PR DESCRIPTION
## Summary

This PR exports the type of the default function.

[This sandbox](https://codesandbox.io/s/2inzf?file=/index.ts) shows this error
<img width="730" alt="image" src="https://user-images.githubusercontent.com/499898/115890566-5cbd0900-a455-11eb-8dc6-d6ebaa8c6e4d.png">

This PR fixes it. ([See →](https://codesandbox.io/s/search-insights-test-in-parcel-forked-56994?file=/index.ts))