### PR TITLE
feat: add getVersion method

### DIFF
--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -64,6 +64,13 @@ describe("Library initialisation", () => {
     });
     expect(analyticsInstance._userToken).not.toBeUndefined();
   });
+
+  it("Should return version", done => {
+    analyticsInstance.getVersion(version => {
+      expect(version).toEqual(expect.stringMatching(/\d+\.\d+\.\d+/));
+      done();
+    });
+  });
 });
 
 describe("Integration tests", () => {
@@ -169,6 +176,16 @@ describe("Integration tests", () => {
             })
         );
         expect(hasCredentials).toBe(true);
+      });
+
+      it("should return version", async () => {
+        const version = await page.evaluate(
+          () =>
+            new Promise(resolve => {
+              window.aa("getVersion", version => resolve(version));
+            })
+        );
+        expect(version).toEqual(expect.stringMatching(/\d+\.\d+\.\d+/));
       });
     });
 

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -65,7 +65,7 @@ describe("Library initialisation", () => {
     expect(analyticsInstance._userToken).not.toBeUndefined();
   });
 
-  it("Should return version", done => {
+  it("should return version", done => {
     analyticsInstance.getVersion(version => {
       expect(version).toEqual(expect.stringMatching(/\d+\.\d+\.\d+/));
       done();

--- a/lib/_getVersion.ts
+++ b/lib/_getVersion.ts
@@ -1,0 +1,7 @@
+import { isFunction } from "./utils";
+
+export function getVersion(callback: (version: string) => void) {
+  if (isFunction(callback)) {
+    callback(this.version);
+  }
+}

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -10,6 +10,7 @@ import { InitParams, init } from "./init";
 import { get, GetCallback } from "./get";
 import { initSearch, InitSearchParams } from "./_initSearch";
 import { addAlgoliaAgent } from "./_algoliaAgent";
+import { getVersion } from "./_getVersion";
 
 import { RequestFnType } from "./utils/request";
 
@@ -88,6 +89,8 @@ class AlgoliaAnalytics {
   public init: (params: InitParams) => void;
   public initSearch: (params: InitSearchParams) => void;
 
+  public getVersion: (callback: (version: string) => void) => void;
+
   public addAlgoliaAgent: (algoliaAgent: string) => void;
 
   public setUserToken: (userToken: string) => void;
@@ -150,6 +153,8 @@ class AlgoliaAnalytics {
     this.viewedFilters = viewedFilters.bind(this);
 
     this._get = get.bind(this);
+
+    this.getVersion = getVersion.bind(this);
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,8 +12,14 @@ import {
   convertedFilters
 } from "./conversion";
 import { viewedObjectIDs, viewedFilters } from "./view";
+import { getVersion } from "./_getVersion";
 
 export type Init = (method: "init", ...args: Parameters<typeof init>) => void;
+
+export type GetVersion = (
+  method: "getVersion",
+  ...args: Parameters<typeof getVersion>
+) => void;
 
 export type AddAlgoliaAgent = (
   method: "addAlgoliaAgent",
@@ -76,6 +82,7 @@ export type ViewedFilters = (
 ) => void;
 
 export type InsightsClient = Init &
+  GetVersion &
   AddAlgoliaAgent &
   SetUserToken &
   GetUserToken &


### PR DESCRIPTION
## Summary

This PR adds `getVersion` method. So far, we've had `version` property in the `AlgoliaAnalytics` class but never exposed a getter method.

In InstantSearch.js, we need this to ensure if the insights middleware is being used with the compatible version of search-insights.