### PR TITLE
fix(types): provide better error messages for insights client

### DIFF
--- a/lib/_getFunctionalInterface.ts
+++ b/lib/_getFunctionalInterface.ts
@@ -7,6 +7,7 @@ export function getFunctionalInterface(
 ): InsightsClient {
   return (functionName, ...functionArguments) => {
     if (functionName && isFunction((instance as any)[functionName])) {
+      // @ts-ignore
       instance[functionName](...functionArguments);
     } else {
       console.warn(`The method \`${functionName}\` doesn't exist.`);

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchClickEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,84 +14,63 @@ import {
 import { viewedObjectIDs, viewedFilters } from "./view";
 import { getVersion } from "./_getVersion";
 
-export type Init = (method: "init", ...args: Parameters<typeof init>) => void;
+type InsightsMethodMap = {
+  init: Parameters<typeof init>;
+  getVersion: Parameters<typeof getVersion>;
+  addAlgoliaAgent: Parameters<typeof addAlgoliaAgent>;
+  setUserToken: Parameters<typeof setUserToken>;
+  getUserToken: Parameters<typeof getUserToken>;
+  onUserTokenChange: Parameters<typeof onUserTokenChange>;
+  clickedObjectIDsAfterSearch: Parameters<typeof clickedObjectIDsAfterSearch>;
+  clickedObjectIDs: Parameters<typeof clickedObjectIDs>;
+  clickedFilters: Parameters<typeof clickedFilters>;
+  convertedObjectIDsAfterSearch: Parameters<
+    typeof convertedObjectIDsAfterSearch
+  >;
+  convertedObjectIDs: Parameters<typeof convertedObjectIDs>;
+  convertedFilters: Parameters<typeof convertedFilters>;
+  viewedObjectIDs: Parameters<typeof viewedObjectIDs>;
+  viewedFilters: Parameters<typeof viewedFilters>;
+};
 
-export type GetVersion = (
-  method: "getVersion",
-  ...args: Parameters<typeof getVersion>
+type MethodType<MethodName extends keyof InsightsMethodMap> = (
+  method: MethodName,
+  ...args: InsightsMethodMap[MethodName]
 ) => void;
 
-export type AddAlgoliaAgent = (
-  method: "addAlgoliaAgent",
-  ...args: Parameters<typeof addAlgoliaAgent>
-) => void;
+export type Init = MethodType<"init">;
 
-export type SetUserToken = (
-  method: "setUserToken",
-  ...args: Parameters<typeof setUserToken>
-) => void;
+export type GetVersion = MethodType<"getVersion">;
 
-export type GetUserToken = (
-  method: "getUserToken",
-  ...args: Parameters<typeof getUserToken>
-) => void;
+export type AddAlgoliaAgent = MethodType<"addAlgoliaAgent">;
 
-export type OnUserTokenChange = (
-  method: "onUserTokenChange",
-  ...args: Parameters<typeof onUserTokenChange>
-) => void;
+export type SetUserToken = MethodType<"setUserToken">;
 
-export type ClickedObjectIDsAfterSearch = (
-  method: "clickedObjectIDsAfterSearch",
-  ...args: Parameters<typeof clickedObjectIDsAfterSearch>
-) => void;
+export type GetUserToken = MethodType<"getUserToken">;
 
-export type ClickedObjectIDs = (
-  method: "clickedObjectIDs",
-  ...args: Parameters<typeof clickedObjectIDs>
-) => void;
+export type OnUserTokenChange = MethodType<"onUserTokenChange">;
 
-export type ClickedFilters = (
-  method: "clickedFilters",
-  ...args: Parameters<typeof clickedFilters>
-) => void;
+export type ClickedObjectIDsAfterSearch = MethodType<
+  "clickedObjectIDsAfterSearch"
+>;
 
-export type ConvertedObjectIDsAfterSearch = (
-  method: "convertedObjectIDsAfterSearch",
-  ...args: Parameters<typeof convertedObjectIDsAfterSearch>
-) => void;
+export type ClickedObjectIDs = MethodType<"clickedObjectIDs">;
 
-export type ConvertedObjectIDs = (
-  method: "convertedObjectIDs",
-  ...args: Parameters<typeof convertedObjectIDs>
-) => void;
+export type ClickedFilters = MethodType<"clickedFilters">;
 
-export type ConvertedFilters = (
-  method: "convertedFilters",
-  ...args: Parameters<typeof convertedFilters>
-) => void;
+export type ConvertedObjectIDsAfterSearch = MethodType<
+  "convertedObjectIDsAfterSearch"
+>;
 
-export type ViewedObjectIDs = (
-  method: "viewedObjectIDs",
-  ...args: Parameters<typeof viewedObjectIDs>
-) => void;
+export type ConvertedObjectIDs = MethodType<"convertedObjectIDs">;
 
-export type ViewedFilters = (
-  method: "viewedFilters",
-  ...args: Parameters<typeof viewedFilters>
-) => void;
+export type ConvertedFilters = MethodType<"convertedFilters">;
 
-export type InsightsClient = Init &
-  GetVersion &
-  AddAlgoliaAgent &
-  SetUserToken &
-  GetUserToken &
-  OnUserTokenChange &
-  ClickedObjectIDsAfterSearch &
-  ClickedObjectIDs &
-  ClickedFilters &
-  ConvertedObjectIDsAfterSearch &
-  ConvertedObjectIDs &
-  ConvertedFilters &
-  ViewedObjectIDs &
-  ViewedFilters;
+export type ViewedObjectIDs = MethodType<"viewedObjectIDs">;
+
+export type ViewedFilters = MethodType<"viewedFilters">;
+
+export type InsightsClient<MethodName extends keyof InsightsMethodMap> = (
+  method: MethodName,
+  params: InsightsMethodMap[MethodName]
+) => void;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,7 @@ import {
 import { viewedObjectIDs, viewedFilters } from "./view";
 import { getVersion } from "./_getVersion";
 
-type InsightsMethodMap = {
+export type InsightsMethodMap = {
   init: Parameters<typeof init>;
   getVersion: Parameters<typeof getVersion>;
   addAlgoliaAgent: Parameters<typeof addAlgoliaAgent>;
@@ -70,7 +70,7 @@ export type ViewedObjectIDs = MethodType<"viewedObjectIDs">;
 
 export type ViewedFilters = MethodType<"viewedFilters">;
 
-export type InsightsClient<MethodName extends keyof InsightsMethodMap> = (
+export type InsightsClient = <MethodName extends keyof InsightsMethodMap>(
   method: MethodName,
-  params: InsightsMethodMap[MethodName]
+  ...args: InsightsMethodMap[MethodName]
 ) => void;


### PR DESCRIPTION
## Summary

This PR updates the type `InsightsClient`. When the second parameter was wrong, TypeScript gave unhelpful error messages. With this change, now it can infer which method is being used, and thus provide better error messages about the second parameter.

fixes: #268

* sandbox: https://codesandbox.io/s/insights-typing-issue-with-clickedobjectidsaftersearch-forked-wzbon?file=/src/index.ts

---

### example 1

```js
insights("init", { appId, apiKeyy: "aaa" });
```

<img width="770" alt="CleanShot 2021-05-26 at 11 03 51@2x" src="https://user-images.githubusercontent.com/499898/119633534-1f5fe880-be12-11eb-8ea3-565536bb5047.png">

### example 2

```js
insights("clickedObjectIDsAfterSearch", {
  userToken: "user-1",
  eventName: "your_event_name",
  index: "your_index_name",
  // queryID: "queryID",
  objectIDs: ["objectID1", "objectID2"],
  positions: [17, 19]
});
```

<img width="537" alt="CleanShot 2021-05-26 at 11 04 00@2x" src="https://user-images.githubusercontent.com/499898/119633566-271f8d00-be12-11eb-970f-eea87ef47080.png">

### example 3

```js
insights('unknown_method');
```

<img width="618" alt="CleanShot 2021-05-26 at 11 09 00@2x" src="https://user-images.githubusercontent.com/499898/119634222-d3617380-be12-11eb-837d-0f908ad71f31.png">

Now it infers the method and provide error messages for that specific method.