### PR TITLE
fix: provide iife build to prevent conflicts with AMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "search-insights",
   "description": "Library for reporting click, conversion and view metrics using the Algolia Insights API",
   "version": "2.0.1",
-  "jsdelivr": "dist/search-insights.min.js",
+  "jsdelivr": "dist/search-insights.iife.min.js",
   "main": "index-node.cjs.js",
   "types": "index-node.cjs.d.ts",
   "browser": "index-browser.cjs.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,5 +54,15 @@ export default [
     },
     external: ["http", "https"],
     plugins: createPlugins()
+  },
+  {
+    input: "lib/entry-umd.ts",
+    output: {
+      format: "iife",
+      name: MODULE_NAME,
+      file: `./dist/${LIBRARY_OUTPUT_NAME}.iife.min.js`
+    },
+    external: ["http", "https"],
+    plugins: createPlugins()
   }
 ];


### PR DESCRIPTION
This will fix https://github.com/algolia/search-insights.js/issues/272 directly loaded UMD does not play nice with RequireJS.
If you're using the snippet, this issue may appear inconsistely depending on the order in which they're ran. 
Ensure insights is loaded after RequireJS to reproduce it consistenly, like this: 

```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
<script src="https://cdn.jsdelivr.net/npm/search-insights@1.7.1/dist/search-insights.min.js"></script>
```
Try it here: https://codesandbox.io/s/elated-lalande-elvc7?file=/index.html:244-449

## Alternative solution
Wrap the UMD build file into (see https://github.com/parcel-bundler/parcel/issues/2451#issuecomment-459590885)

```js
(function(){
   var define = null
   // UMD build content goes here
})()
```
This should be easy enough to do, but the IIFE build is a simpler and smaller solution.
