### PR TITLE
fix(types): make eventName required

### DIFF
--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -5,7 +5,7 @@ export type InsightsEventType = "click" | "conversion" | "view";
 export type InsightsEvent = {
   eventType: InsightsEventType;
 
-  eventName?: string;
+  eventName: string;
   userToken: string;
   timestamp?: number;
   index: string;

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,6 +1,7 @@
 import { InsightsEvent } from "./_sendEvent";
 
 export interface InsightsSearchConversionEvent {
+  eventName: string;
   userToken?: string;
   timestamp?: number;
   index: string;


### PR DESCRIPTION
## Summary

This PR adds `eventName` to `InsightsSearchConversionEvent`. It was missing.