### PR TITLE
fix(bundle): remove unnecessary exports from bundles

### DIFF
--- a/lib/entry-browser-cjs.ts
+++ b/lib/entry-browser-cjs.ts
@@ -1,10 +1,9 @@
 import AlgoliaAnalytics from "./insights";
 import { getFunctionalInterface } from "./_getFunctionalInterface";
 import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
-import { getRequesterForNode } from "./utils/getRequesterForNode";
 import { RequestFnType } from "./utils/request";
 
-export { getRequesterForBrowser, getRequesterForNode };
+export { getRequesterForBrowser };
 export * from "./types";
 
 export function createInsightsClient(requestFn: RequestFnType) {

--- a/lib/entry-node-cjs.ts
+++ b/lib/entry-node-cjs.ts
@@ -1,10 +1,9 @@
 import AlgoliaAnalytics from "./insights";
 import { getFunctionalInterface } from "./_getFunctionalInterface";
-import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { getRequesterForNode } from "./utils/getRequesterForNode";
 import { RequestFnType } from "./utils/request";
 
-export { getRequesterForBrowser, getRequesterForNode };
+export { getRequesterForNode };
 export * from "./types";
 
 export function createInsightsClient(requestFn: RequestFnType) {


### PR DESCRIPTION
## Summary

This PR removes

- `getRequesterForNode` from `entry-browser-cjs`
- `getRequesterForBrowser` from `entry-node-cjs`

They seem unnecessary.

It also breaks React Native (#319). It resolves `entry-browser-cjs` but it tries to resolve all the dependencies regarding `getRequesterForNode`, and fails.

This may be seen as a breaking change, but I doubt if there's any case where they resolve `entry-browser-cjs` AND need requester for node. Feel free to create an issue for discussion if you have such needs.