### PR TITLE
chore(circleci): update node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,15 @@ aliases:
     name: Install dependencies
     command: yarn install
 
-node_v8: &node_v8
+node_v10: &node_v10
   working_directory: ~/search-insights
   docker:
-    - image: circleci/node:8.16.0-browsers
+    - image: cimg/node:10.24.1-browsers
 
 node_v12: &node_v12
   working_directory: ~/search-insights
   docker:
-    - image: circleci/node:12.14.1@sha256:62d7dc3a6cca1e5225333d995ba66e2abb1aed61adeaf6029fb320654d632b38
+    - image: cimg/node:12.14.1
 
 version: 2
 jobs:
@@ -62,7 +62,7 @@ jobs:
           command: yarn run type-check
 
   "unit tests":
-    <<: *node_v8
+    <<: *node_v10
     steps:
       - checkout
       - run: *install_yarn_version


### PR DESCRIPTION
## Summary

Updating node image in CircleCI.

Although we support `node >= 8.16.0`, unfortunately there is no image for that under `cimg/node:`.
We should drop node v8 but not in this PR.

same as https://github.com/algolia/instantsearch.js/pull/4918

---

Question: I think we can drop node v8 and have v10 as minimum supported version, without having to bump the major version of search-insights. What do you think?