### PR TITLE
feat: support multiple events

### DIFF
--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -32,7 +32,8 @@ describe("_sendEvent in node env", () => {
 
   it("does not throw when user token is not set", () => {
     expect(() => {
-      aa("sendEvent", "click", {
+      aa("sendEvent", {
+        eventType: "click",
         ...defaultPayload
       });
     }).not.toThrowError();
@@ -52,7 +53,8 @@ describe("_sendEvent in node env", () => {
 
   it("does not throw when user token is included", () => {
     expect(() => {
-      aa("sendEvent", "click", {
+      aa("sendEvent", {
+        eventType: "click",
         ...defaultPayload,
         userToken: "aaa"
       });

--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -32,10 +32,12 @@ describe("_sendEvent in node env", () => {
 
   it("does not throw when user token is not set", () => {
     expect(() => {
-      aa("sendEvent", {
-        eventType: "click",
-        ...defaultPayload
-      });
+      aa("sendEvents", [
+        {
+          eventType: "click",
+          ...defaultPayload
+        }
+      ]);
     }).not.toThrowError();
 
     expect(requestFn).toHaveBeenCalledWith(defaultRequestUrl, {
@@ -53,11 +55,13 @@ describe("_sendEvent in node env", () => {
 
   it("does not throw when user token is included", () => {
     expect(() => {
-      aa("sendEvent", {
-        eventType: "click",
-        ...defaultPayload,
-        userToken: "aaa"
-      });
+      aa("sendEvents", [
+        {
+          eventType: "click",
+          ...defaultPayload,
+          userToken: "aaa"
+        }
+      ]);
     }).not.toThrowError();
 
     expect(requestFn).toHaveBeenCalledWith(defaultRequestUrl, {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -363,4 +363,90 @@ describe("sendEvent", () => {
       });
     });
   });
+
+  describe("multiple events", () => {
+    let analyticsInstance: AlgoliaAnalytics;
+    const fakeRequestFn = jest.fn();
+
+    beforeEach(() => {
+      fakeRequestFn.mockClear();
+      analyticsInstance = setupInstance(fakeRequestFn);
+    });
+
+    it("should send multiple events via clickedObjectIDs", () => {
+      analyticsInstance.clickedObjectIDs(
+        {
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        {
+          eventName: "my-event-2",
+          index: "my-index-2",
+          objectIDs: ["2"]
+        }
+      );
+
+      expect(fakeRequestFn).toHaveBeenCalledWith(
+        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
+        {
+          events: [
+            {
+              eventName: "my-event",
+              eventType: "click",
+              index: "my-index",
+              objectIDs: ["1"],
+              userToken: "mock-user-id"
+            },
+            {
+              eventName: "my-event-2",
+              eventType: "click",
+              index: "my-index-2",
+              objectIDs: ["2"],
+              userToken: "mock-user-id"
+            }
+          ]
+        }
+      );
+    });
+
+    it("should send multiple events via sendEvent", () => {
+      analyticsInstance.sendEvent(
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        },
+        {
+          eventType: "click",
+          eventName: "my-event-2",
+          index: "my-index-2",
+          objectIDs: ["2"]
+        }
+      );
+
+      expect(fakeRequestFn).toHaveBeenCalledWith(
+        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
+        {
+          events: [
+            {
+              eventName: "my-event",
+              eventType: "click",
+              index: "my-index",
+              objectIDs: ["1"],
+              userToken: "mock-user-id"
+            },
+            {
+              eventName: "my-event-2",
+              eventType: "click",
+              index: "my-index-2",
+              objectIDs: ["2"],
+              userToken: "mock-user-id"
+            }
+          ]
+        }
+      );
+    });
+  });
 });

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -46,7 +46,8 @@ describe("sendEvent", () => {
       window.navigator.sendBeacon = sendBeaconBackup;
     });
     it("should make a post request to /1/events", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -57,7 +58,8 @@ describe("sendEvent", () => {
       expect(url.parse(requestUrl).pathname).toBe("/1/events");
     });
     it("should pass over the payload with multiple events", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -73,7 +75,8 @@ describe("sendEvent", () => {
       });
     });
     it("should include X-Algolia-* query parameters", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -101,7 +104,8 @@ describe("sendEvent", () => {
       window.navigator.sendBeacon = sendBeaconBackup;
     });
     it("should use sendBeacon when available", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -111,7 +115,8 @@ describe("sendEvent", () => {
       expect(XMLHttpRequest.send).not.toHaveBeenCalled();
     });
     it("should call sendBeacon with /1/event", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -121,7 +126,8 @@ describe("sendEvent", () => {
       expect(url.parse(requestURL).pathname).toBe("/1/events");
     });
     it("should send the correct payload", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -137,7 +143,8 @@ describe("sendEvent", () => {
       });
     });
     it("should include X-Algolia-* query parameters", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -161,7 +168,8 @@ describe("sendEvent", () => {
       analyticsInstance = setupInstance(fakeRequestFn);
     });
     it("should call the requestFn with expected arguments", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -186,7 +194,8 @@ describe("sendEvent", () => {
     it("should allow a promise to be returned from requestFn", () => {
       fakeRequestFn.mockImplementationOnce(() => Promise.resolve("test"));
 
-      const result = (analyticsInstance as any).sendEvent("click", {
+      const result = (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -213,7 +222,8 @@ describe("sendEvent", () => {
     });
     it("should do nothing is _userHasOptedOut === true", () => {
       analyticsInstance._userHasOptedOut = true;
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -229,7 +239,8 @@ describe("sendEvent", () => {
     });
 
     it("should support multiple objectIDs and positions", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1", "2"],
@@ -255,7 +266,8 @@ describe("sendEvent", () => {
     });
 
     it("should not add a timestamp if not provided", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -265,7 +277,8 @@ describe("sendEvent", () => {
       expect(payload.events[0]).not.toHaveProperty("timestamp");
     });
     it("should pass over provided timestamp", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"],
@@ -290,7 +303,8 @@ describe("sendEvent", () => {
     });
 
     it("should add a userToken if not provided", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"]
@@ -306,7 +320,8 @@ describe("sendEvent", () => {
       });
     });
     it("should pass over provided userToken", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         objectIDs: ["1"],
@@ -331,7 +346,8 @@ describe("sendEvent", () => {
     });
 
     it("should pass over provided filters", () => {
-      (analyticsInstance as any).sendEvent("click", {
+      (analyticsInstance as any).sendEvent({
+        eventType: "click",
         eventName: "my-event",
         index: "my-index",
         filters: ["brand:Apple"]

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -19,7 +19,7 @@ function setupInstance(requestFn = getRequesterForBrowser()) {
   return instance;
 }
 
-describe("sendEvent", () => {
+describe("sendEvents", () => {
   let XMLHttpRequest;
 
   beforeEach(() => {
@@ -46,24 +46,28 @@ describe("sendEvent", () => {
       window.navigator.sendBeacon = sendBeaconBackup;
     });
     it("should make a post request to /1/events", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(XMLHttpRequest.open).toHaveBeenCalledTimes(1);
       const [verb, requestUrl] = XMLHttpRequest.open.mock.calls[0];
       expect(verb).toBe("POST");
       expect(url.parse(requestUrl).pathname).toBe("/1/events");
     });
     it("should pass over the payload with multiple events", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -75,12 +79,14 @@ describe("sendEvent", () => {
       });
     });
     it("should include X-Algolia-* query parameters", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       const requestUrl = XMLHttpRequest.open.mock.calls[0][1];
       const { query } = url.parse(requestUrl);
       expect(querystring.parse(query)).toEqual({
@@ -104,34 +110,40 @@ describe("sendEvent", () => {
       window.navigator.sendBeacon = sendBeaconBackup;
     });
     it("should use sendBeacon when available", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(sendBeacon).toHaveBeenCalledTimes(1);
       expect(XMLHttpRequest.open).not.toHaveBeenCalled();
       expect(XMLHttpRequest.send).not.toHaveBeenCalled();
     });
     it("should call sendBeacon with /1/event", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       const [requestURL] = sendBeacon.mock.calls[0];
 
       expect(url.parse(requestURL).pathname).toBe("/1/events");
     });
     it("should send the correct payload", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       const payload = JSON.parse(sendBeacon.mock.calls[0][1]);
 
       expect(payload).toEqual({
@@ -143,12 +155,14 @@ describe("sendEvent", () => {
       });
     });
     it("should include X-Algolia-* query parameters", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       const requestUrl = sendBeacon.mock.calls[0][0];
       const { query } = url.parse(requestUrl);
       expect(querystring.parse(query)).toEqual({
@@ -168,12 +182,14 @@ describe("sendEvent", () => {
       analyticsInstance = setupInstance(fakeRequestFn);
     });
     it("should call the requestFn with expected arguments", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
 
       expect(fakeRequestFn).toHaveBeenCalledWith(
         "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
@@ -194,12 +210,14 @@ describe("sendEvent", () => {
     it("should allow a promise to be returned from requestFn", () => {
       fakeRequestFn.mockImplementationOnce(() => Promise.resolve("test"));
 
-      const result = (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      const result = (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
 
       expect(result instanceof Promise).toBe(true);
       expect(result).resolves.toBe("test");
@@ -215,19 +233,21 @@ describe("sendEvent", () => {
     it("should throw if init was not called", () => {
       expect(() => {
         (analyticsInstance as any)._hasCredentials = false;
-        (analyticsInstance as any).sendEvent();
+        (analyticsInstance as any).sendEvents();
       }).toThrowError(
         "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
       );
     });
     it("should do nothing is _userHasOptedOut === true", () => {
       analyticsInstance._userHasOptedOut = true;
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(0);
     });
   });
@@ -239,13 +259,15 @@ describe("sendEvent", () => {
     });
 
     it("should support multiple objectIDs and positions", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1", "2"],
-        positions: [3, 5]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1", "2"],
+          positions: [3, 5]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -266,24 +288,28 @@ describe("sendEvent", () => {
     });
 
     it("should not add a timestamp if not provided", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload.events[0]).not.toHaveProperty("timestamp");
     });
     it("should pass over provided timestamp", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"],
-        timestamp: 1984
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"],
+          timestamp: 1984
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -303,12 +329,14 @@ describe("sendEvent", () => {
     });
 
     it("should add a userToken if not provided", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -320,13 +348,15 @@ describe("sendEvent", () => {
       });
     });
     it("should pass over provided userToken", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        objectIDs: ["1"],
-        userToken: "007"
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"],
+          userToken: "007"
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -346,12 +376,14 @@ describe("sendEvent", () => {
     });
 
     it("should pass over provided filters", () => {
-      (analyticsInstance as any).sendEvent({
-        eventType: "click",
-        eventName: "my-event",
-        index: "my-index",
-        filters: ["brand:Apple"]
-      });
+      (analyticsInstance as any).sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          filters: ["brand:Apple"]
+        }
+      ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
       expect(payload).toEqual({
@@ -410,8 +442,8 @@ describe("sendEvent", () => {
       );
     });
 
-    it("should send multiple events via sendEvent", () => {
-      analyticsInstance.sendEvent(
+    it("should send multiple events via sendEvents", () => {
+      analyticsInstance.sendEvents([
         {
           eventType: "click",
           eventName: "my-event",
@@ -424,7 +456,7 @@ describe("sendEvent", () => {
           index: "my-index-2",
           objectIDs: ["2"]
         }
-      );
+      ]);
 
       expect(fakeRequestFn).toHaveBeenCalledWith(
         "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 describe("clickedObjectIDsAfterSearch", () => {
-  test("Should call sendEvent with proper params", () => {
+  test("Should call sendEvents with proper params", () => {
     const clickParams = {
       positions: [1],
       objectIDs: ["2"],
@@ -19,46 +19,52 @@ describe("clickedObjectIDsAfterSearch", () => {
     };
 
     analyticsInstance.init(credentials);
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.clickedObjectIDsAfterSearch(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "click",
-      ...clickParams
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "click",
+        ...clickParams
+      }
+    ]);
   });
 });
 
 describe("clickedObjectIDs", () => {
-  it("should call sendEvent with proper params", () => {
+  it("should call sendEvents with proper params", () => {
     const clickParams = {
       objectIDs: ["2"]
     };
 
     analyticsInstance.init(credentials);
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.clickedObjectIDs(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "click",
-      ...clickParams
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "click",
+        ...clickParams
+      }
+    ]);
   });
 });
 
 describe("clickedFilters", () => {
-  it("should call sendEvent with proper params", () => {
+  it("should call sendEvents with proper params", () => {
     const clickParams = {
       filters: ["brands:apple"]
     };
 
     analyticsInstance.init(credentials);
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.clickedFilters(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "click",
-      ...clickParams
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "click",
+        ...clickParams
+      }
+    ]);
   });
 });

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -22,10 +22,10 @@ describe("clickedObjectIDsAfterSearch", () => {
     (analyticsInstance as any).sendEvent = jest.fn();
     analyticsInstance.clickedObjectIDsAfterSearch(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "click",
-      clickParams
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "click",
+      ...clickParams
+    });
   });
 });
 
@@ -39,10 +39,10 @@ describe("clickedObjectIDs", () => {
     (analyticsInstance as any).sendEvent = jest.fn();
     analyticsInstance.clickedObjectIDs(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "click",
-      clickParams
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "click",
+      ...clickParams
+    });
   });
 });
 
@@ -56,9 +56,9 @@ describe("clickedFilters", () => {
     (analyticsInstance as any).sendEvent = jest.fn();
     analyticsInstance.clickedFilters(clickParams);
 
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "click",
-      clickParams
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "click",
+      ...clickParams
+    });
   });
 });

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -18,10 +18,11 @@ describe("convertedObjectIDsAfterSearch", () => {
       queryID: "test"
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "conversion",
-      { objectIDs: ["12345"], queryID: "test" }
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "conversion",
+      objectIDs: ["12345"],
+      queryID: "test"
+    });
   });
 });
 
@@ -38,10 +39,10 @@ describe("convertedObjectIDs", () => {
       objectIDs: ["12345"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "conversion",
-      { objectIDs: ["12345"] }
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "conversion",
+      objectIDs: ["12345"]
+    });
   });
 });
 
@@ -58,9 +59,9 @@ describe("convertedFilters", () => {
       filters: ["brands:apple"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith(
-      "conversion",
-      { filters: ["brands:apple"] }
-    );
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "conversion",
+      filters: ["brands:apple"]
+    });
   });
 });

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -11,18 +11,20 @@ describe("convertedObjectIDsAfterSearch", () => {
   });
 
   it("Should send allow passing of queryID", () => {
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.init(credentials);
     analyticsInstance.convertedObjectIDsAfterSearch({
       objectIDs: ["12345"],
       queryID: "test"
     });
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "conversion",
-      objectIDs: ["12345"],
-      queryID: "test"
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalled();
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "conversion",
+        objectIDs: ["12345"],
+        queryID: "test"
+      }
+    ]);
   });
 });
 
@@ -33,16 +35,18 @@ describe("convertedObjectIDs", () => {
   });
 
   it("should send allow passing of queryID", () => {
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.init(credentials);
     analyticsInstance.convertedObjectIDs({
       objectIDs: ["12345"]
     });
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "conversion",
-      objectIDs: ["12345"]
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalled();
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "conversion",
+        objectIDs: ["12345"]
+      }
+    ]);
   });
 });
 
@@ -53,15 +57,17 @@ describe("convertedFilters", () => {
   });
 
   it("should send allow passing of queryID", () => {
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.init(credentials);
     analyticsInstance.convertedFilters({
       filters: ["brands:apple"]
     });
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "conversion",
-      filters: ["brands:apple"]
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalled();
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "conversion",
+        filters: ["brands:apple"]
+      }
+    ]);
   });
 });

--- a/lib/__tests__/view.test.ts
+++ b/lib/__tests__/view.test.ts
@@ -17,7 +17,8 @@ describe("viewedObjectIDs", () => {
       objectIDs: ["12345"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith("view", {
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "view",
       objectIDs: ["12345"]
     });
   });
@@ -36,7 +37,8 @@ describe("viewedFilters", () => {
       filters: ["brands:apple"]
     });
     expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith("view", {
+    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
+      eventType: "view",
       filters: ["brands:apple"]
     });
   });

--- a/lib/__tests__/view.test.ts
+++ b/lib/__tests__/view.test.ts
@@ -11,16 +11,18 @@ describe("viewedObjectIDs", () => {
   });
 
   it("should send allow passing of queryID", () => {
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.init(credentials);
     analyticsInstance.viewedObjectIDs({
       objectIDs: ["12345"]
     });
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "view",
-      objectIDs: ["12345"]
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalled();
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "view",
+        objectIDs: ["12345"]
+      }
+    ]);
   });
 });
 
@@ -31,15 +33,17 @@ describe("viewedFilters", () => {
   });
 
   it("should send allow passing of queryID", () => {
-    (analyticsInstance as any).sendEvent = jest.fn();
+    (analyticsInstance as any).sendEvents = jest.fn();
     analyticsInstance.init(credentials);
     analyticsInstance.viewedFilters({
       filters: ["brands:apple"]
     });
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalled();
-    expect((analyticsInstance as any).sendEvent).toHaveBeenCalledWith({
-      eventType: "view",
-      filters: ["brands:apple"]
-    });
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalled();
+    expect((analyticsInstance as any).sendEvents).toHaveBeenCalledWith([
+      {
+        eventType: "view",
+        filters: ["brands:apple"]
+      }
+    ]);
   });
 });

--- a/lib/_addEventType.ts
+++ b/lib/_addEventType.ts
@@ -1,0 +1,11 @@
+import { InsightsEvent, InsightsEventType } from "./types";
+
+export function addEventType(
+  eventType: InsightsEventType,
+  params: Array<Omit<InsightsEvent, "eventType">>
+): InsightsEvent[] {
+  return params.map(event => ({
+    eventType,
+    ...event
+  }));
+}

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -18,8 +18,7 @@ export type InsightsEvent = {
 
 export function makeSendEvent(requestFn: RequestFnType) {
   return function sendEvent(
-    eventType: InsightsEventType,
-    eventData?: InsightsEvent
+    ...eventData: InsightsEvent[]
   ) {
     if (this._userHasOptedOut) {
       return;
@@ -30,24 +29,23 @@ export function makeSendEvent(requestFn: RequestFnType) {
       );
     }
 
-    const event: InsightsEvent = {
-      ...eventData,
-      eventType,
-      userToken: eventData?.userToken ?? this._userToken
-    };
+    const events: InsightsEvent[] = eventData.map(data => ({
+      ...data,
+      userToken: data?.userToken ?? this._userToken
+    }))
 
-    return bulkSendEvent(
+    return sendRequest(
       requestFn,
       this._appId,
       this._apiKey,
       this._uaURIEncoded,
       this._endpointOrigin,
-      [event]
+      events
     );
   };
 }
 
-function bulkSendEvent(
+function sendRequest(
   requestFn: RequestFnType,
   appId: string,
   apiKey: string,

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,20 +1,5 @@
 import { RequestFnType } from "./utils/request";
-
-export type InsightsEventType = "click" | "conversion" | "view";
-export type InsightsEvent = {
-  eventType: InsightsEventType;
-
-  eventName: string;
-  userToken: string;
-  timestamp?: number;
-  index: string;
-
-  queryID?: string;
-  objectIDs?: string[];
-  positions?: number[];
-
-  filters?: string[];
-};
+import { InsightsEvent } from './types'
 
 export function makeSendEvent(requestFn: RequestFnType) {
   return function sendEvent(

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,9 +1,9 @@
 import { RequestFnType } from "./utils/request";
 import { InsightsEvent } from './types'
 
-export function makeSendEvent(requestFn: RequestFnType) {
-  return function sendEvent(
-    ...eventData: InsightsEvent[]
+export function makeSendEvents(requestFn: RequestFnType) {
+  return function sendEvents(
+    eventData: InsightsEvent[]
   ) {
     if (this._userHasOptedOut) {
       return;

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,5 +1,3 @@
-import { InsightsEvent } from "./_sendEvent";
-
 export interface InsightsSearchClickEvent {
   eventName: string;
   userToken?: string;
@@ -16,7 +14,7 @@ export interface InsightsSearchClickEvent {
  * @param params: InsightsSearchClickEvent
  */
 export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent({ eventType: "click", ...params });
 }
 
 export interface InsightsClickObjectIDsEvent {
@@ -33,7 +31,7 @@ export interface InsightsClickObjectIDsEvent {
  * @param params: InsightsClickObjectIDsEvent
  */
 export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent({ eventType: "click", ...params });
 }
 
 export interface InsightsClickFiltersEvent {
@@ -50,5 +48,5 @@ export interface InsightsClickFiltersEvent {
  * @param params: InsightsClickFiltersEvent
  */
 export function clickedFilters(params: InsightsClickFiltersEvent) {
-  this.sendEvent("click", params as InsightsEvent);
+  this.sendEvent({ eventType: "click", ...params });
 }

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,3 +1,5 @@
+import { addEventType } from "./_addEventType";
+
 export interface InsightsSearchClickEvent {
   eventName: string;
   userToken?: string;
@@ -9,12 +11,10 @@ export interface InsightsSearchClickEvent {
   positions: number[];
 }
 
-/**
- * Sends a click report in the context of search
- * @param params: InsightsSearchClickEvent
- */
-export function clickedObjectIDsAfterSearch(params: InsightsSearchClickEvent) {
-  this.sendEvent({ eventType: "click", ...params });
+export function clickedObjectIDsAfterSearch(
+  ...params: InsightsSearchClickEvent[]
+) {
+  return this.sendEvent(...addEventType("click", params));
 }
 
 export interface InsightsClickObjectIDsEvent {
@@ -26,12 +26,8 @@ export interface InsightsClickObjectIDsEvent {
   objectIDs: string[];
 }
 
-/**
- * Sends a click report using objectIDs, outside the context of a search
- * @param params: InsightsClickObjectIDsEvent
- */
-export function clickedObjectIDs(params: InsightsClickObjectIDsEvent) {
-  this.sendEvent({ eventType: "click", ...params });
+export function clickedObjectIDs(...params: InsightsClickObjectIDsEvent[]) {
+  return this.sendEvent(...addEventType("click", params));
 }
 
 export interface InsightsClickFiltersEvent {
@@ -43,10 +39,6 @@ export interface InsightsClickFiltersEvent {
   filters: string[];
 }
 
-/**
- * Sends a click report using filters
- * @param params: InsightsClickFiltersEvent
- */
-export function clickedFilters(params: InsightsClickFiltersEvent) {
-  this.sendEvent({ eventType: "click", ...params });
+export function clickedFilters(...params: InsightsClickFiltersEvent[]) {
+  return this.sendEvent(...addEventType("click", params));
 }

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -14,7 +14,7 @@ export interface InsightsSearchClickEvent {
 export function clickedObjectIDsAfterSearch(
   ...params: InsightsSearchClickEvent[]
 ) {
-  return this.sendEvent(...addEventType("click", params));
+  return this.sendEvents(addEventType("click", params));
 }
 
 export interface InsightsClickObjectIDsEvent {
@@ -27,7 +27,7 @@ export interface InsightsClickObjectIDsEvent {
 }
 
 export function clickedObjectIDs(...params: InsightsClickObjectIDsEvent[]) {
-  return this.sendEvent(...addEventType("click", params));
+  return this.sendEvents(addEventType("click", params));
 }
 
 export interface InsightsClickFiltersEvent {
@@ -40,5 +40,5 @@ export interface InsightsClickFiltersEvent {
 }
 
 export function clickedFilters(...params: InsightsClickFiltersEvent[]) {
-  return this.sendEvent(...addEventType("click", params));
+  return this.sendEvents(addEventType("click", params));
 }

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,3 +1,4 @@
+import { addEventType } from "./_addEventType";
 export interface InsightsSearchConversionEvent {
   eventName: string;
   userToken?: string;
@@ -8,14 +9,10 @@ export interface InsightsSearchConversionEvent {
   objectIDs: string[];
 }
 
-/**
- * Sends a conversion report in the context of search
- * @param params InsightsSearchConversionEvent
- */
 export function convertedObjectIDsAfterSearch(
-  params: InsightsSearchConversionEvent
+  ...params: InsightsSearchConversionEvent[]
 ) {
-  this.sendEvent({ eventType: "conversion", ...params });
+  return this.sendEvent(...addEventType("conversion", params));
 }
 
 export interface InsightsSearchConversionObjectIDsEvent {
@@ -26,14 +23,11 @@ export interface InsightsSearchConversionObjectIDsEvent {
 
   objectIDs: string[];
 }
-/**
- * Sends a conversion report using objectIDs
- * @param params InsightsSearchConversionObjectIDsEvent
- */
+
 export function convertedObjectIDs(
-  params: InsightsSearchConversionObjectIDsEvent
+  ...params: InsightsSearchConversionObjectIDsEvent[]
 ) {
-  this.sendEvent({ eventType: "conversion", ...params });
+  return this.sendEvent(...addEventType("conversion", params));
 }
 
 export interface InsightsSearchConversionFiltersEvent {
@@ -44,10 +38,9 @@ export interface InsightsSearchConversionFiltersEvent {
 
   filters: string[];
 }
-/**
- * Sends a conversion report using filters, outside the context of a search
- * @param params InsightsSearchConversionFiltersEvent
- */
-export function convertedFilters(params: InsightsSearchConversionFiltersEvent) {
-  this.sendEvent({ eventType: "conversion", ...params });
+
+export function convertedFilters(
+  ...params: InsightsSearchConversionFiltersEvent[]
+) {
+  return this.sendEvent(...addEventType("conversion", params));
 }

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -12,7 +12,7 @@ export interface InsightsSearchConversionEvent {
 export function convertedObjectIDsAfterSearch(
   ...params: InsightsSearchConversionEvent[]
 ) {
-  return this.sendEvent(...addEventType("conversion", params));
+  return this.sendEvents(addEventType("conversion", params));
 }
 
 export interface InsightsSearchConversionObjectIDsEvent {
@@ -27,7 +27,7 @@ export interface InsightsSearchConversionObjectIDsEvent {
 export function convertedObjectIDs(
   ...params: InsightsSearchConversionObjectIDsEvent[]
 ) {
-  return this.sendEvent(...addEventType("conversion", params));
+  return this.sendEvents(addEventType("conversion", params));
 }
 
 export interface InsightsSearchConversionFiltersEvent {
@@ -42,5 +42,5 @@ export interface InsightsSearchConversionFiltersEvent {
 export function convertedFilters(
   ...params: InsightsSearchConversionFiltersEvent[]
 ) {
-  return this.sendEvent(...addEventType("conversion", params));
+  return this.sendEvents(addEventType("conversion", params));
 }

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,5 +1,3 @@
-import { InsightsEvent } from "./_sendEvent";
-
 export interface InsightsSearchConversionEvent {
   eventName: string;
   userToken?: string;
@@ -17,7 +15,7 @@ export interface InsightsSearchConversionEvent {
 export function convertedObjectIDsAfterSearch(
   params: InsightsSearchConversionEvent
 ) {
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent({ eventType: "conversion", ...params });
 }
 
 export interface InsightsSearchConversionObjectIDsEvent {
@@ -35,7 +33,7 @@ export interface InsightsSearchConversionObjectIDsEvent {
 export function convertedObjectIDs(
   params: InsightsSearchConversionObjectIDsEvent
 ) {
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent({ eventType: "conversion", ...params });
 }
 
 export interface InsightsSearchConversionFiltersEvent {
@@ -51,5 +49,5 @@ export interface InsightsSearchConversionFiltersEvent {
  * @param params InsightsSearchConversionFiltersEvent
  */
 export function convertedFilters(params: InsightsSearchConversionFiltersEvent) {
-  this.sendEvent("conversion", params as InsightsEvent);
+  this.sendEvent({ eventType: "conversion", ...params });
 }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -66,7 +66,6 @@ class AlgoliaAnalytics {
 
   version: string = version;
 
-  protected sendEvent: ReturnType<typeof makeSendEvent>;
   protected _hasCredentials: boolean = false;
 
   // Public methods
@@ -78,6 +77,8 @@ class AlgoliaAnalytics {
   public setAnonymousUserToken: typeof setAnonymousUserToken;
   public getUserToken: typeof getUserToken;
   public onUserTokenChange: typeof onUserTokenChange;
+
+  public sendEvent: ReturnType<typeof makeSendEvent>;
 
   public clickedObjectIDsAfterSearch: typeof clickedObjectIDsAfterSearch;
   public clickedObjectIDs: typeof clickedObjectIDs;
@@ -91,10 +92,8 @@ class AlgoliaAnalytics {
   public viewedFilters: typeof viewedFilters;
 
   constructor({ requestFn }: { requestFn: RequestFnType }) {
-    // Bind private methods to `this` class
     this.sendEvent = makeSendEvent(requestFn).bind(this);
 
-    // Bind public methods to `this` class
     this.init = init.bind(this);
 
     this.addAlgoliaAgent = addAlgoliaAgent.bind(this);

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -4,7 +4,7 @@ import objectKeysPolyfill from "./polyfills/objectKeys";
 objectKeysPolyfill();
 objectAssignPolyfill();
 
-import { makeSendEvent } from "./_sendEvent";
+import { makeSendEvents } from "./_sendEvent";
 
 import { init } from "./init";
 import { addAlgoliaAgent } from "./_algoliaAgent";
@@ -78,7 +78,7 @@ class AlgoliaAnalytics {
   public getUserToken: typeof getUserToken;
   public onUserTokenChange: typeof onUserTokenChange;
 
-  public sendEvent: ReturnType<typeof makeSendEvent>;
+  public sendEvents: ReturnType<typeof makeSendEvents>;
 
   public clickedObjectIDsAfterSearch: typeof clickedObjectIDsAfterSearch;
   public clickedObjectIDs: typeof clickedObjectIDs;
@@ -92,7 +92,7 @@ class AlgoliaAnalytics {
   public viewedFilters: typeof viewedFilters;
 
   constructor({ requestFn }: { requestFn: RequestFnType }) {
-    this.sendEvent = makeSendEvent(requestFn).bind(this);
+    this.sendEvents = makeSendEvents(requestFn).bind(this);
 
     this.init = init.bind(this);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,7 @@ import {
 } from "./conversion";
 import { viewedObjectIDs, viewedFilters } from "./view";
 import { getVersion } from "./_getVersion";
+import { makeSendEvents } from "./_sendEvent";
 
 export type InsightsMethodMap = {
   init: Parameters<typeof init>;
@@ -31,6 +32,7 @@ export type InsightsMethodMap = {
   convertedFilters: Parameters<typeof convertedFilters>;
   viewedObjectIDs: Parameters<typeof viewedObjectIDs>;
   viewedFilters: Parameters<typeof viewedFilters>;
+  sendEvents: Parameters<ReturnType<typeof makeSendEvents>>;
 };
 
 type MethodType<MethodName extends keyof InsightsMethodMap> = (
@@ -69,6 +71,8 @@ export type ConvertedFilters = MethodType<"convertedFilters">;
 export type ViewedObjectIDs = MethodType<"viewedObjectIDs">;
 
 export type ViewedFilters = MethodType<"viewedFilters">;
+
+export type SendEvents = MethodType<"sendEvents">;
 
 export type InsightsClient = <MethodName extends keyof InsightsMethodMap>(
   method: MethodName,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,3 +74,20 @@ export type InsightsClient = <MethodName extends keyof InsightsMethodMap>(
   method: MethodName,
   ...args: InsightsMethodMap[MethodName]
 ) => void;
+
+export type InsightsEventType = "click" | "conversion" | "view";
+
+export type InsightsEvent = {
+  eventType: InsightsEventType;
+
+  eventName: string;
+  userToken?: string;
+  timestamp?: number;
+  index: string;
+
+  queryID?: string;
+  objectIDs?: string[];
+  positions?: number[];
+
+  filters?: string[];
+};

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -10,7 +10,7 @@ export interface InsightsSearchViewObjectIDsEvent {
 }
 
 export function viewedObjectIDs(...params: InsightsSearchViewObjectIDsEvent[]) {
-  return this.sendEvent(...addEventType("view", params));
+  return this.sendEvents(addEventType("view", params));
 }
 
 export interface InsightsSearchViewFiltersEvent {
@@ -23,5 +23,5 @@ export interface InsightsSearchViewFiltersEvent {
 }
 
 export function viewedFilters(...params: InsightsSearchViewFiltersEvent[]) {
-  return this.sendEvent(...addEventType("view", params));
+  return this.sendEvents(addEventType("view", params));
 }

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -1,3 +1,5 @@
+import { addEventType } from "./_addEventType";
+
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
   userToken?: string;
@@ -6,12 +8,9 @@ export interface InsightsSearchViewObjectIDsEvent {
 
   objectIDs: string[];
 }
-/**
- * Sends a view report using objectIDs
- * @param params InsightsSearchViewObjectIDsEvent
- */
-export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
-  this.sendEvent({ eventType: "view", ...params });
+
+export function viewedObjectIDs(...params: InsightsSearchViewObjectIDsEvent[]) {
+  return this.sendEvent(...addEventType("view", params));
 }
 
 export interface InsightsSearchViewFiltersEvent {
@@ -22,10 +21,7 @@ export interface InsightsSearchViewFiltersEvent {
 
   filters: string[];
 }
-/**
- * Sends a view report using filters
- * @param params InsightsSearchViewFiltersEvent
- */
-export function viewedFilters(params: InsightsSearchViewFiltersEvent) {
-  this.sendEvent({ eventType: "view", ...params });
+
+export function viewedFilters(...params: InsightsSearchViewFiltersEvent[]) {
+  return this.sendEvent(...addEventType("view", params));
 }

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -1,5 +1,3 @@
-import { InsightsEvent } from "./_sendEvent";
-
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
   userToken?: string;
@@ -13,7 +11,7 @@ export interface InsightsSearchViewObjectIDsEvent {
  * @param params InsightsSearchViewObjectIDsEvent
  */
 export function viewedObjectIDs(params: InsightsSearchViewObjectIDsEvent) {
-  this.sendEvent("view", params as InsightsEvent);
+  this.sendEvent({ eventType: "view", ...params });
 }
 
 export interface InsightsSearchViewFiltersEvent {
@@ -29,5 +27,5 @@ export interface InsightsSearchViewFiltersEvent {
  * @param params InsightsSearchViewFiltersEvent
  */
 export function viewedFilters(params: InsightsSearchViewFiltersEvent) {
-  this.sendEvent("view", params as InsightsEvent);
+  this.sendEvent({ eventType: "view", ...params });
 }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "bundlesize": [
     {
       "path": "./dist/search-insights.min.js",
-      "maxSize": "2.3 kB"
+      "maxSize": "2.4 kB"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR enables sending multiple events in a single request.

search-insights has not supported sending multiple events, although [the REST API](https://www.algolia.com/doc/rest-api/insights/#push-events) already does.

- viewedObjectIDs
- viewedFilters
- clickedObjectIDsAfterSearch
- clickedObjectIDs
- clickedFilters
- convertedObjectIDsAfterSearch
- convertedObjectIDs
- convertedFilters

The methods above now can take multiple event payloads as arguments.

Also `sendEvent` method that used to be `protected` is now `public`. Its signature has changed, but it was never documented and an internal method, so I don't consider this a breaking change.