### PR TITLE
fix: fall back to XHR if sendBeacon returns false

### DIFF
--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -94,7 +94,7 @@ describe("sendEvent", () => {
     let sendBeaconBackup;
     beforeEach(() => {
       sendBeaconBackup = window.navigator.sendBeacon;
-      sendBeacon = window.navigator.sendBeacon = jest.fn();
+      sendBeacon = window.navigator.sendBeacon = jest.fn(() => true);
       analyticsInstance = setupInstance();
     });
     afterEach(() => {

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -15,7 +15,7 @@ describe("request", () => {
   const sendBeaconBackup = navigator.sendBeacon;
   const XMLHttpRequestBackup = window.XMLHttpRequest;
 
-  const sendBeacon = jest.fn();
+  const sendBeacon = jest.fn(() => true);
   const open = jest.fn();
   const send = jest.fn();
   const write = jest.fn();
@@ -79,6 +79,25 @@ describe("request", () => {
     const request = getRequesterForBrowser();
     request(url, data);
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenLastCalledWith("POST", url);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
+    expect(nodeHttpRequest).not.toHaveBeenCalled();
+    expect(nodeHttpsRequest).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to XMLHttpRequest if sendBeacon returns false", () => {
+    navigator.sendBeacon = jest.fn(() => false);
+    supportsSendBeacon.mockImplementation(() => true);
+    supportsXMLHttpRequest.mockImplementation(() => true);
+    supportsNodeHttpModule.mockImplementation(() => false);
+    const url = "https://random.url";
+    const data = { foo: "bar" };
+    const request = getRequesterForBrowser();
+    request(url, data);
+    expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+
     expect(open).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -2,7 +2,9 @@ export type RequestFnType = (url: string, data: object) => void;
 
 export const requestWithSendBeacon: RequestFnType = (url, data) => {
   const serializedData = JSON.stringify(data);
-  navigator.sendBeacon(url, serializedData);
+  if (!navigator.sendBeacon(url, serializedData)) {
+    return requestWithXMLHttpRequest(url, data);
+  }
 };
 
 export const requestWithXMLHttpRequest: RequestFnType = (url, data) => {


### PR DESCRIPTION
## Summary

`sendBeacon` can return `false` if it fails to add the request to the browser queue.
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon#return_values

In that case, we need to send the event in different way, otherwise we lose it. So we fall back to XHR if `sendBeacon` returns `false`.