### PR TITLE
chore: schedule release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,8 @@ jobs:
       - run:
           name: Prepare release
           command: |
-            git config --global user.email "eunjae.lee@algolia.com"
-            git config --global user.name "Eunjae Lee"
+            git config --global user.email "algobot@users.noreply.github.com"
+            git config --global user.name "algobot"
             yarn run release --yes --no-browse
 
 workflows:
@@ -116,7 +116,7 @@ workflows:
   prepare_release_every_tuesday:
     triggers:
       - schedule:
-          cron: '0 9 * * 2'
+          cron: "0 9 * * 2"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,20 @@ jobs:
           name: Trigger a release if the latest commit is a release commit
           command: |
             yarn shipjs trigger
+  "prepare release":
+    <<: *node_v12
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Prepare release
+          command: |
+            git config --global user.email "eunjae.lee@algolia.com"
+            git config --global user.name "Eunjae Lee"
+            yarn run release --yes --no-browse
 
 workflows:
   version: 2
@@ -99,3 +113,13 @@ workflows:
             branches:
               only:
                 - master
+  prepare_release_every_tuesday:
+    triggers:
+      - schedule:
+          cron: '0 9 * * 2'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - prepare_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,4 +122,4 @@ workflows:
               only:
                 - master
     jobs:
-      - prepare_release
+      - prepare release

--- a/ship.config.js
+++ b/ship.config.js
@@ -2,6 +2,13 @@ const fs = require("fs");
 const path = require("path");
 
 module.exports = {
+  shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
+    const { fix = 0 } = commitNumbersPerType;
+    if (releaseType === 'patch' && fix === 0) {
+      return false;
+    }
+    return true;
+  },
   buildCommand: () => "yarn build && /bin/bash ./pre-deploy.sh",
   pullRequestTeamReviewers: ["@algolia/instantsearch-for-websites"],
   versionUpdated: ({ version, releaseType, dir }) => {


### PR DESCRIPTION
## Summary

This PR schedules release every Tuesday 11am (Paris time). It doesn't automatically releases the new version, but just calls `shipjs prepare` to create a release pull-request.