### PR TITLE
docs: fix README regarding onUserTokenChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ aa('onUserTokenChange', callback, options);
 | `immediate` | `boolean`  | Fire the callback as soon as it's attached     |
 
 ```js
-aa('init', { ... });  // ← This sets an anonymous user token if cookie is available.
+aa('init', { ..., useCookie: true });  // ← This sets an anonymous user token if cookie is available.
 
 aa('onUserTokenChange', (userToken) => {
   console.log(userToken);  // prints out the anonymous user token


### PR DESCRIPTION
## Summary

This PR updates the README regarding `onUserTokenChange`.
The previous one was valid until search-insights@1, but not anymore since v2.