### PR TITLE
refactor: uri-encode user agent right before sending events

### DIFF
--- a/lib/__tests__/_algoliaAgent.test.ts
+++ b/lib/__tests__/_algoliaAgent.test.ts
@@ -4,33 +4,49 @@ jest.mock("../../package.json", () => ({ version: "1.0.1" }));
 
 describe("algoliaAgent", () => {
   let analyticsInstance;
+  let requestFn;
+
   beforeEach(() => {
-    analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
+    requestFn = jest.fn();
+    analyticsInstance = new AlgoliaAnalytics({ requestFn });
     analyticsInstance.init({ apiKey: "test", appId: "test" });
   });
 
   it("should initialize the client with a default algoliaAgent string", () => {
-    expect(analyticsInstance._ua).toEqual("insights-js (1.0.1)");
-    expect(analyticsInstance._uaURIEncoded).toEqual("insights-js%20(1.0.1)");
+    expect(analyticsInstance._ua).toEqual(["insights-js (1.0.1)"]);
   });
 
   it("should allow adding a string to algoliaAgent", () => {
     analyticsInstance.addAlgoliaAgent("other string");
-    expect(analyticsInstance._ua).toEqual("insights-js (1.0.1); other string");
-    expect(analyticsInstance._uaURIEncoded).toEqual(
-      "insights-js%20(1.0.1)%3B%20other%20string"
-    );
+    expect(analyticsInstance._ua).toEqual([
+      "insights-js (1.0.1)",
+      "other string"
+    ]);
   });
 
   it("should duplicate a string when added twice", () => {
     analyticsInstance.addAlgoliaAgent("duplicated string");
     analyticsInstance.addAlgoliaAgent("duplicated string");
 
-    expect(analyticsInstance._ua).toEqual(
-      "insights-js (1.0.1); duplicated string"
-    );
-    expect(analyticsInstance._uaURIEncoded).toEqual(
-      "insights-js%20(1.0.1)%3B%20duplicated%20string"
+    expect(analyticsInstance._ua).toEqual([
+      "insights-js (1.0.1)",
+      "duplicated string"
+    ]);
+  });
+
+  it("should be joined and encoded for URL", () => {
+    analyticsInstance.addAlgoliaAgent("other string");
+    analyticsInstance.sendEvents([
+      {
+        eventType: "click",
+        eventName: "my-event",
+        index: "my-index",
+        objectIDs: ["1"]
+      }
+    ]);
+
+    expect(requestFn.mock.calls[0][0]).toEqual(
+      "https://insights.algolia.io/1/events?X-Algolia-Application-Id=test&X-Algolia-API-Key=test&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20other%20string"
     );
   });
 });

--- a/lib/_algoliaAgent.ts
+++ b/lib/_algoliaAgent.ts
@@ -3,8 +3,7 @@ import { version } from "../package.json";
 export const DEFAULT_ALGOLIA_AGENT = `insights-js (${version})`;
 
 export function addAlgoliaAgent(algoliaAgent) {
-  if (this._ua.indexOf(`; ${algoliaAgent}`) === -1) {
-    this._ua += `; ${algoliaAgent}`;
-    this._uaURIEncoded = encodeURIComponent(this._ua);
+  if (this._ua.indexOf(algoliaAgent) === -1) {
+    this._ua.push(algoliaAgent);
   }
 }

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,5 +1,5 @@
 import { RequestFnType } from "./utils/request";
-import { InsightsEvent } from './types'
+import { InsightsEvent } from "./types";
 
 export function makeSendEvents(requestFn: RequestFnType) {
   return function sendEvents(
@@ -23,7 +23,7 @@ export function makeSendEvents(requestFn: RequestFnType) {
       requestFn,
       this._appId,
       this._apiKey,
-      this._uaURIEncoded,
+      this._ua,
       this._endpointOrigin,
       events
     );
@@ -34,11 +34,12 @@ function sendRequest(
   requestFn: RequestFnType,
   appId: string,
   apiKey: string,
-  userAgent: string,
+  userAgents: string[],
   endpointOrigin: string,
   events: InsightsEvent[]
 ) {
   // Auth query
-  const reportingURL = `${endpointOrigin}/1/events?X-Algolia-Application-Id=${appId}&X-Algolia-API-Key=${apiKey}&X-Algolia-Agent=${userAgent}`;
+  const ua = encodeURIComponent(userAgents.join('; '));
+  const reportingURL = `${endpointOrigin}/1/events?X-Algolia-Application-Id=${appId}&X-Algolia-API-Key=${apiKey}&X-Algolia-Agent=${ua}`;
   return requestFn(reportingURL, { events });
 }

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -76,8 +76,7 @@ You can visit https://algolia.com/events/debugger instead.`);
   this._hasCredentials = true;
 
   // user agent
-  this._ua = DEFAULT_ALGOLIA_AGENT;
-  this._uaURIEncoded = encodeURIComponent(DEFAULT_ALGOLIA_AGENT);
+  this._ua = [DEFAULT_ALGOLIA_AGENT];
 
   if (options.userToken) {
     this.setUserToken(options.userToken);

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -61,8 +61,7 @@ class AlgoliaAnalytics {
   _cookieDuration: number;
 
   // user agent
-  _ua: string = "";
-  _uaURIEncoded: string = "";
+  _ua: string[] = [];
 
   version: string = version;
 


### PR DESCRIPTION
## Summary

This PR removes `_uaURIEncoded`, and uri-encodes it right before sending events. Previously it was a string being concatenated as new bits were added. Now it's an array, and gets joined with `;` later on.