### PR TITLE
chore: add library flavor to algolia agent

### DIFF
--- a/lib/__tests__/_algoliaAgent.test.ts
+++ b/lib/__tests__/_algoliaAgent.test.ts
@@ -13,13 +13,17 @@ describe("algoliaAgent", () => {
   });
 
   it("should initialize the client with a default algoliaAgent string", () => {
-    expect(analyticsInstance._ua).toEqual(["insights-js (1.0.1)"]);
+    expect(analyticsInstance._ua).toEqual([
+      "insights-js (1.0.1)",
+      "insights-js-node-cjs (1.0.1)"
+    ]);
   });
 
   it("should allow adding a string to algoliaAgent", () => {
     analyticsInstance.addAlgoliaAgent("other string");
     expect(analyticsInstance._ua).toEqual([
       "insights-js (1.0.1)",
+      "insights-js-node-cjs (1.0.1)",
       "other string"
     ]);
   });
@@ -30,6 +34,7 @@ describe("algoliaAgent", () => {
 
     expect(analyticsInstance._ua).toEqual([
       "insights-js (1.0.1)",
+      "insights-js-node-cjs (1.0.1)",
       "duplicated string"
     ]);
   });
@@ -46,7 +51,7 @@ describe("algoliaAgent", () => {
     ]);
 
     expect(requestFn.mock.calls[0][0]).toEqual(
-      "https://insights.algolia.io/1/events?X-Algolia-Application-Id=test&X-Algolia-API-Key=test&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20other%20string"
+      "https://insights.algolia.io/1/events?X-Algolia-Application-Id=test&X-Algolia-API-Key=test&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20insights-js-node-cjs%20(1.0.1)%3B%20other%20string"
     );
   });
 });

--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -18,7 +18,7 @@ const defaultPayload = {
   objectIDs: ["1"]
 };
 
-const defaultRequestUrl = `https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(${version})`;
+const defaultRequestUrl = `https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(${version})%3B%20insights-js-node-cjs%20(${version})`;
 
 describe("_sendEvent in node env", () => {
   let aa;

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -91,7 +91,7 @@ describe("sendEvents", () => {
       const { query } = url.parse(requestUrl);
       expect(querystring.parse(query)).toEqual({
         "X-Algolia-API-Key": "testKey",
-        "X-Algolia-Agent": "insights-js (1.0.1)",
+        "X-Algolia-Agent": "insights-js (1.0.1); insights-js-node-cjs (1.0.1)",
         "X-Algolia-Application-Id": "testId"
       });
     });
@@ -167,7 +167,7 @@ describe("sendEvents", () => {
       const { query } = url.parse(requestUrl);
       expect(querystring.parse(query)).toEqual({
         "X-Algolia-API-Key": "testKey",
-        "X-Algolia-Agent": "insights-js (1.0.1)",
+        "X-Algolia-Agent": "insights-js (1.0.1); insights-js-node-cjs (1.0.1)",
         "X-Algolia-Application-Id": "testId"
       });
     });
@@ -192,7 +192,7 @@ describe("sendEvents", () => {
       ]);
 
       expect(fakeRequestFn).toHaveBeenCalledWith(
-        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
+        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20insights-js-node-cjs%20(1.0.1)",
         {
           events: [
             {
@@ -420,7 +420,7 @@ describe("sendEvents", () => {
       );
 
       expect(fakeRequestFn).toHaveBeenCalledWith(
-        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
+        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20insights-js-node-cjs%20(1.0.1)",
         {
           events: [
             {
@@ -459,7 +459,7 @@ describe("sendEvents", () => {
       ]);
 
       expect(fakeRequestFn).toHaveBeenCalledWith(
-        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)",
+        "https://insights.algolia.io/1/events?X-Algolia-Application-Id=testId&X-Algolia-API-Key=testKey&X-Algolia-Agent=insights-js%20(1.0.1)%3B%20insights-js-node-cjs%20(1.0.1)",
         {
           events: [
             {

--- a/lib/_algoliaAgent.ts
+++ b/lib/_algoliaAgent.ts
@@ -1,6 +1,9 @@
 import { version } from "../package.json";
 
-export const DEFAULT_ALGOLIA_AGENT = `insights-js (${version})`;
+export const DEFAULT_ALGOLIA_AGENTS = [
+  `insights-js (${version})`,
+  `insights-js-${__FLAVOR__} (${version})`
+];
 
 export function addAlgoliaAgent(algoliaAgent) {
   if (this._ua.indexOf(algoliaAgent) === -1) {

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,5 +1,5 @@
 import { isUndefined, isString, isNumber } from "./utils";
-import { DEFAULT_ALGOLIA_AGENT } from "./_algoliaAgent";
+import { DEFAULT_ALGOLIA_AGENTS } from "./_algoliaAgent";
 
 type InsightRegion = "de" | "us";
 const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
@@ -76,7 +76,7 @@ You can visit https://algolia.com/events/debugger instead.`);
   this._hasCredentials = true;
 
   // user agent
-  this._ua = [DEFAULT_ALGOLIA_AGENT];
+  this._ua = [...DEFAULT_ALGOLIA_AGENTS];
 
   if (options.userToken) {
     this.setUserToken(options.userToken);

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -1,3 +1,4 @@
 declare module "*/package.json";
 
 declare const __DEV__: boolean;
+declare const __FLAVOR__: string;

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
       "jest-watch-typeahead/testname"
     ],
     "globals": {
-      "__DEV__": true
+      "__DEV__": true,
+      "__FLAVOR__": "node-cjs"
     }
   },
   "dependencies": {},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ import replace from "rollup-plugin-replace";
 const MODULE_NAME = "AlgoliaAnalytics",
   LIBRARY_OUTPUT_NAME = "search-insights";
 
-const createPlugins = ({ format }) => [
+const createPlugins = ({ format, flavor }) => [
   typescript(),
   resolve({
     preferBuiltins: false
@@ -24,6 +24,7 @@ const createPlugins = ({ format }) => [
       format === "umd" || format === "iife"
         ? false
         : 'process.env.NODE_ENV === "development"',
+    __FLAVOR__: JSON.stringify(flavor),
     exclude: ["package.json"]
   }),
   buble(),
@@ -41,7 +42,7 @@ export default [
       file: `./dist/${LIBRARY_OUTPUT_NAME}.min.js`,
       globals: {}
     },
-    plugins: createPlugins({ format: "umd" })
+    plugins: createPlugins({ format: "umd", flavor: "browser-umd" })
   },
   {
     input: "lib/entry-node-cjs.ts",
@@ -51,7 +52,7 @@ export default [
       file: `./dist/${LIBRARY_OUTPUT_NAME}-node.cjs.min.js`
     },
     external: ["http", "https"],
-    plugins: createPlugins({ format: "cjs" })
+    plugins: createPlugins({ format: "cjs", flavor: "node-cjs" })
   },
   {
     input: "lib/entry-browser-cjs.ts",
@@ -61,7 +62,7 @@ export default [
       file: `./dist/${LIBRARY_OUTPUT_NAME}-browser.cjs.min.js`
     },
     external: ["http", "https"],
-    plugins: createPlugins({ format: "cjs" })
+    plugins: createPlugins({ format: "cjs", flavor: "browser-cjs" })
   },
   {
     input: "lib/entry-umd.ts",
@@ -70,6 +71,6 @@ export default [
       name: MODULE_NAME,
       file: `./dist/${LIBRARY_OUTPUT_NAME}.iife.min.js`
     },
-    plugins: createPlugins({ format: "iife" })
+    plugins: createPlugins({ format: "iife", flavor: "browser-iife" })
   }
 ];


### PR DESCRIPTION
## Summary

This PR adds library flavor as algolia agent.

![Screenshot 2021-12-09 at 16 49 35](https://user-images.githubusercontent.com/499898/145429228-268a7e9e-a6be-4977-b016-3e5515934e06.png)

A global variable `__FLAVOR__` is added (`node-cjs` in dev mode), and is replaced at build time.

With this addition, we can get _insights_ on how many people are using which flavor of search-insights.

**Flavors:**
- browser-umd
- browser-cjs
- browser-iife
- node-cjs

**Example:**
Open [the sandbox](https://codesandbox.io/s/vanilla-forked-ol43i?file=/src/index.js) and see the network panel.