### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ aa('sendEvents', [
 | ----------- | ------------------------------- | ---------------------------------------------- |
 | `eventType` | `view`                          | `click` | `conversion` | The name of the index related to the event.    |
 | `eventName` | `string`                        | The name of the event.                         |
-| `userToken` | `string` (optional)             | You can specify userToken per event. |
+| `userToken` | `string` (optional)             | search-insights uses anonymous user token or a token set by `setUserToken` method. You can override it by providing a `userToken` per event object. |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ aa('sendEvents', [
 
 | Option      | Type                            | Description                                    |
 | ----------- | ------------------------------- | ---------------------------------------------- |
-| `eventType` | `view`                          | `click` | `conversion` | The name of the index related to the event     |
-| `eventName` | `string`                        | The name of the event                          |
+| `eventType` | `view`                          | `click` | `conversion` | The name of the index related to the event.    |
+| `eventName` | `string`                        | The name of the event.                         |
 | `userToken` | `string` (optional)             | You can specify userToken per event. |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -402,6 +402,27 @@ aa('viewedFilters', {
 | `eventName` | `string`   | The name of the event                                            |
 | `filters`   | `string[]` | The list of filters that was clicked as `'${attr}${op}${value}'` |
 
+### Batch Events
+
+You can send multiple events in a single HTTP request, by using `sendEvents` method.
+
+```js
+aa('sendEvents', [
+  {
+    eventType,
+    eventName,
+    userToken,
+    ...
+  }
+]);
+```
+
+| Option      | Type                            | Description                                    |
+| ----------- | ------------------------------- | ---------------------------------------------- |
+| `eventType` | `view`                          | `click` | `conversion` | The name of the index related to the event     |
+| `eventName` | `string`                        | The name of the event                          |
+| `userToken` | `string` (optional)             | You can specify userToken per event. |
+
 ## Examples
 
 The following examples assume that the Search Insights library is loaded.


### PR DESCRIPTION
## Summary

This PR updates README to include `sendEvents` method, which was introduced in https://github.com/algolia/search-insights.js/pull/335, but the doc wasn't updated.