### PR TITLE
fix: add default `Content-Type` and `Content-Length` headers to `XMLHttpRequest` instance

### DIFF
--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -18,6 +18,7 @@ describe("request", () => {
   const sendBeacon = jest.fn(() => true);
   const open = jest.fn();
   const send = jest.fn();
+  const setRequestHeader = jest.fn();
   const write = jest.fn();
 
   beforeEach(() => {
@@ -29,6 +30,7 @@ describe("request", () => {
     window.XMLHttpRequest = function() {
       this.open = open;
       this.send = send;
+      this.setRequestHeader = setRequestHeader;
     };
     nodeHttpRequest.mockImplementation(() => {
       return {
@@ -66,6 +68,7 @@ describe("request", () => {
     );
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
+    expect(setRequestHeader).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
   });
@@ -80,6 +83,7 @@ describe("request", () => {
     request(url, data);
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
+    expect(setRequestHeader).toHaveBeenCalledTimes(2);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -99,6 +103,7 @@ describe("request", () => {
     expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
 
     expect(open).toHaveBeenCalledTimes(1);
+    expect(setRequestHeader).toHaveBeenCalledTimes(2);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -117,6 +122,7 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
+    expect(setRequestHeader).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
     expect(nodeHttpRequest).toHaveBeenLastCalledWith({
       protocol: "http:",
@@ -143,6 +149,7 @@ describe("request", () => {
     request(url, data);
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
+    expect(setRequestHeader).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).toHaveBeenLastCalledWith({

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -11,6 +11,8 @@ export const requestWithXMLHttpRequest: RequestFnType = (url, data) => {
   const serializedData = JSON.stringify(data);
   const report = new XMLHttpRequest();
   report.open("POST", url);
+  report.setRequestHeader("Content-Type", "application/json");
+  report.setRequestHeader("Content-Length", `${serializedData.length}`);
   report.send(serializedData);
 };
 


### PR DESCRIPTION
React Native for Android wasn't setting a `Content-Type` header and requests were failing silently since we don't set the `XMLHttpRequest.onerror` callback.
For this second point, I'll create an issue, and we should discuss about what's the right way to handle this by default.