### PR TITLE
fix: handle XMLHttpRequest errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ const { createInsightsClient } = require("search-insights");
 // OR via the UMD
 const createInsightsClient = window.AlgoliaAnalytics.createInsightsClient;
 
-function requestFn(url, data) {
+function requestFn(url, data, options) {
   const serializedData = JSON.stringify(data);
   const { protocol, host, path } = require("url").parse(url);
-  const options = {
+  const reqOptions = {
     protocol,
     host,
     path,
@@ -164,10 +164,12 @@ function requestFn(url, data) {
 
   const { request: nodeRequest } =
     url.indexOf("https://") === 0 ? require("https") : require("http");
-  const req = nodeRequest(options);
+  const req = nodeRequest(reqOptions);
 
   req.on("error", error => {
     console.error(error);
+    // or use the `onError` callback
+    options?.errorCallback?.(error);
   });
 
   req.write(serializedData);
@@ -422,6 +424,17 @@ aa('sendEvents', [
 | `eventType` | `'view'` \| `'click'` \| `'conversion'` | The name of the index related to the event.    |
 | `eventName` | `string`                        | The name of the event.                         |
 | `userToken` | `string` (optional)             | search-insights uses anonymous user token or a token set by `setUserToken` method. You can override it by providing a `userToken` per event object. |
+
+### Handling request errors
+
+You can set an error callback which will be called whenever an error happens during a request.
+
+```js
+aa('onError', (event) => {
+    console.error(event);
+    throw new Error("Oops!");
+});
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,6 @@ You can set an error callback which will be called whenever an error happens dur
 ```js
 aa('onError', (event) => {
     console.error(event);
-    throw new Error("Oops!");
 });
 ```
 

--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -28,7 +28,6 @@ describe("_sendEvent in node env", () => {
     const instance = new AlgoliaAnalytics({ requestFn });
     aa = getFunctionalInterface(instance);
     aa("init", credentials);
-    // aa("onError", console.error);
   });
 
   it("does not throw when user token is not set", () => {

--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -28,6 +28,7 @@ describe("_sendEvent in node env", () => {
     const instance = new AlgoliaAnalytics({ requestFn });
     aa = getFunctionalInterface(instance);
     aa("init", credentials);
+    // aa("onError", console.error);
   });
 
   it("does not throw when user token is not set", () => {
@@ -40,17 +41,21 @@ describe("_sendEvent in node env", () => {
       ]);
     }).not.toThrowError();
 
-    expect(requestFn).toHaveBeenCalledWith(defaultRequestUrl, {
-      events: [
-        {
-          eventName: "my-event",
-          eventType: "click",
-          index: "my-index",
-          objectIDs: ["1"],
-          userToken: undefined
-        }
-      ]
-    });
+    expect(requestFn).toHaveBeenCalledWith(
+      defaultRequestUrl,
+      {
+        events: [
+          {
+            eventName: "my-event",
+            eventType: "click",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: undefined
+          }
+        ]
+      },
+      { errorCallback: undefined }
+    );
   });
 
   it("does not throw when user token is included", () => {
@@ -64,16 +69,50 @@ describe("_sendEvent in node env", () => {
       ]);
     }).not.toThrowError();
 
-    expect(requestFn).toHaveBeenCalledWith(defaultRequestUrl, {
-      events: [
+    expect(requestFn).toHaveBeenCalledWith(
+      defaultRequestUrl,
+      {
+        events: [
+          {
+            eventName: "my-event",
+            eventType: "click",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: "aaa"
+          }
+        ]
+      },
+      { errorCallback: undefined }
+    );
+  });
+
+  it("forwards an error callback", () => {
+    const errorCallback = err => {};
+    aa("onError", errorCallback);
+    expect(() => {
+      aa("sendEvents", [
         {
-          eventName: "my-event",
           eventType: "click",
-          index: "my-index",
-          objectIDs: ["1"],
+          ...defaultPayload,
           userToken: "aaa"
         }
-      ]
-    });
+      ]);
+    }).not.toThrowError();
+
+    expect(requestFn).toHaveBeenCalledWith(
+      defaultRequestUrl,
+      {
+        events: [
+          {
+            eventName: "my-event",
+            eventType: "click",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: "aaa"
+          }
+        ]
+      },
+      { errorCallback }
+    );
   });
 });

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -121,6 +121,9 @@ describe("sendEvents", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith("Mocked request failure");
+
+      XMLHttpRequest.send.mockRestore();
+      XMLHttpRequest.addEventListener.mockRestore();
     });
   });
 

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -203,7 +203,8 @@ describe("sendEvents", () => {
               userToken: "mock-user-id"
             }
           ]
-        }
+        },
+        { errorCallback: undefined }
       );
     });
 
@@ -458,7 +459,8 @@ describe("sendEvents", () => {
               userToken: "mock-user-id"
             }
           ]
-        }
+        },
+        { errorCallback: undefined }
       );
     });
 
@@ -497,7 +499,8 @@ describe("sendEvents", () => {
               userToken: "mock-user-id"
             }
           ]
-        }
+        },
+        { errorCallback: undefined }
       );
     });
   });

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,6 +1,6 @@
 import { RequestFnType } from "./utils/request";
 import { InsightsEvent } from './types'
-import {isFunction, isUndefined} from "./utils";
+import { isFunction, isUndefined } from "./utils";
 
 export function makeSendEvents(requestFn: RequestFnType) {
   return function sendEvents(

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -4,7 +4,7 @@ import objectKeysPolyfill from "./polyfills/objectKeys";
 objectKeysPolyfill();
 objectAssignPolyfill();
 
-import { makeSendEvents } from "./_sendEvent";
+import { makeSendEvents, onError } from "./_sendEvent";
 
 import { init } from "./init";
 import { addAlgoliaAgent } from "./_algoliaAgent";
@@ -90,6 +90,8 @@ class AlgoliaAnalytics {
   public viewedObjectIDs: typeof viewedObjectIDs;
   public viewedFilters: typeof viewedFilters;
 
+  public onError: typeof onError;
+
   constructor({ requestFn }: { requestFn: RequestFnType }) {
     this.sendEvents = makeSendEvents(requestFn).bind(this);
 
@@ -116,6 +118,8 @@ class AlgoliaAnalytics {
     this.viewedFilters = viewedFilters.bind(this);
 
     this.getVersion = getVersion.bind(this);
+
+    this.onError = onError.bind(this);
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,7 +13,7 @@ import {
 } from "./conversion";
 import { viewedObjectIDs, viewedFilters } from "./view";
 import { getVersion } from "./_getVersion";
-import { makeSendEvents } from "./_sendEvent";
+import { makeSendEvents, onError } from "./_sendEvent";
 
 export type InsightsMethodMap = {
   init: Parameters<typeof init>;
@@ -33,6 +33,7 @@ export type InsightsMethodMap = {
   viewedObjectIDs: Parameters<typeof viewedObjectIDs>;
   viewedFilters: Parameters<typeof viewedFilters>;
   sendEvents: Parameters<ReturnType<typeof makeSendEvents>>;
+  onError: Parameters<typeof onError>;
 };
 
 type MethodType<MethodName extends keyof InsightsMethodMap> = (
@@ -73,6 +74,8 @@ export type ViewedObjectIDs = MethodType<"viewedObjectIDs">;
 export type ViewedFilters = MethodType<"viewedFilters">;
 
 export type SendEvents = MethodType<"sendEvents">;
+
+export type OnError = MethodType<"onError">;
 
 export type InsightsClient = <MethodName extends keyof InsightsMethodMap>(
   method: MethodName,

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -19,7 +19,6 @@ describe("request", () => {
   const open = jest.fn();
   const send = jest.fn();
   const setRequestHeader = jest.fn();
-  const addEventListener = jest.fn();
   const write = jest.fn();
 
   beforeEach(() => {
@@ -32,7 +31,6 @@ describe("request", () => {
       this.open = open;
       this.send = send;
       this.setRequestHeader = setRequestHeader;
-      this.addEventListener = addEventListener;
     };
     nodeHttpRequest.mockImplementation(() => {
       return {
@@ -71,7 +69,6 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
-    expect(addEventListener).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
   });
@@ -87,26 +84,6 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
-    expect(addEventListener).not.toHaveBeenCalled();
-    expect(open).toHaveBeenLastCalledWith("POST", url);
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
-    expect(nodeHttpRequest).not.toHaveBeenCalled();
-    expect(nodeHttpsRequest).not.toHaveBeenCalled();
-  });
-
-  it("should handle XMLHttpRequest error with given callback", () => {
-    supportsSendBeacon.mockImplementation(() => false);
-    supportsXMLHttpRequest.mockImplementation(() => true);
-    supportsNodeHttpModule.mockImplementation(() => true);
-    const url = "https://random.url";
-    const data = { foo: "bar" };
-    const request = getRequesterForBrowser();
-    request(url, data, { errorCallback: err => {} });
-    expect(navigator.sendBeacon).not.toHaveBeenCalled();
-    expect(open).toHaveBeenCalledTimes(1);
-    expect(setRequestHeader).toHaveBeenCalledTimes(2);
-    expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -128,7 +105,6 @@ describe("request", () => {
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
     expect(open).toHaveBeenLastCalledWith("POST", url);
-    expect(addEventListener).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
     expect(nodeHttpRequest).not.toHaveBeenCalled();
@@ -147,7 +123,6 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
-    expect(addEventListener).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
     expect(nodeHttpRequest).toHaveBeenLastCalledWith({
       protocol: "http:",
@@ -175,7 +150,6 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
-    expect(addEventListener).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).toHaveBeenLastCalledWith({

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -87,6 +87,25 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
+    expect(addEventListener).not.toHaveBeenCalled();
+    expect(open).toHaveBeenLastCalledWith("POST", url);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
+    expect(nodeHttpRequest).not.toHaveBeenCalled();
+    expect(nodeHttpsRequest).not.toHaveBeenCalled();
+  });
+
+  it("should handle XMLHttpRequest error with given callback", () => {
+    supportsSendBeacon.mockImplementation(() => false);
+    supportsXMLHttpRequest.mockImplementation(() => true);
+    supportsNodeHttpModule.mockImplementation(() => true);
+    const url = "https://random.url";
+    const data = { foo: "bar" };
+    const request = getRequesterForBrowser();
+    request(url, data, { errorCallback: err => {} });
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(setRequestHeader).toHaveBeenCalledTimes(2);
     expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
@@ -108,8 +127,8 @@ describe("request", () => {
 
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
-    expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
+    expect(addEventListener).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
     expect(nodeHttpRequest).not.toHaveBeenCalled();

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -19,6 +19,7 @@ describe("request", () => {
   const open = jest.fn();
   const send = jest.fn();
   const setRequestHeader = jest.fn();
+  const addEventListener = jest.fn();
   const write = jest.fn();
 
   beforeEach(() => {
@@ -31,6 +32,7 @@ describe("request", () => {
       this.open = open;
       this.send = send;
       this.setRequestHeader = setRequestHeader;
+      this.addEventListener = addEventListener;
     };
     nodeHttpRequest.mockImplementation(() => {
       return {
@@ -69,6 +71,7 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
   });
@@ -84,6 +87,7 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
+    expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -104,6 +108,7 @@ describe("request", () => {
 
     expect(open).toHaveBeenCalledTimes(1);
     expect(setRequestHeader).toHaveBeenCalledTimes(2);
+    expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -123,6 +128,7 @@ describe("request", () => {
     expect(open).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).not.toHaveBeenCalled();
     expect(nodeHttpRequest).toHaveBeenLastCalledWith({
       protocol: "http:",
@@ -150,6 +156,7 @@ describe("request", () => {
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
     expect(setRequestHeader).not.toHaveBeenCalled();
+    expect(addEventListener).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(nodeHttpRequest).not.toHaveBeenCalled();
     expect(nodeHttpsRequest).toHaveBeenLastCalledWith({

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -10,6 +10,15 @@ export const requestWithSendBeacon: RequestFnType = (url, data) => {
 export const requestWithXMLHttpRequest: RequestFnType = (url, data) => {
   const serializedData = JSON.stringify(data);
   const report = new XMLHttpRequest();
+  report.addEventListener("error", event => {
+    if (event && event.currentTarget) {
+      console.error(
+        "XMLHttpRequest failed to send the request",
+        event.currentTarget
+      );
+    }
+    throw new Error("XMLHttpRequest failed to send the request");
+  });
   report.open("POST", url);
   report.setRequestHeader("Content-Type", "application/json");
   report.setRequestHeader("Content-Length", `${serializedData.length}`);


### PR DESCRIPTION
🎟️ JIRA Ticket: [DI-612](https://algolia.atlassian.net/browse/DI-612)

In order to avoid failing silently without recourse when an XHR doesn't come through, this PR adds the ability to plug an error callback on the requesting function.

For example, when using `XmlHttpRequest`, this snippet will use `addEventListener('error', onErrorCallback)` to plug the callback to the request:
```js
aa('onError', console.error);
```