### PR TITLE
feat(api): expose window.AlgoliaAnalyticsObject if not yet set

### DIFF
--- a/examples/instantsearch/instantsearch.html
+++ b/examples/instantsearch/instantsearch.html
@@ -6,17 +6,17 @@
     <script>
       !(function(e, a, t, n, s, i, c) {
         (e.AlgoliaAnalyticsObject = s),
-          (e.aa =
-            e.aa ||
-            function() {
-              (e.aa.queue = e.aa.queue || []).push(arguments);
+          (e[s] =
+            e[s] ||
+            function () {
+              (e[s].queue = e[s].queue || []).push(arguments);
             }),
           (i = a.createElement(t)),
           (c = a.getElementsByTagName(t)[0]),
           (i.async = 1),
-          (i.src = "@@SCRIPT_SRC"),
+          (i.src = n),
           c.parentNode.insertBefore(i, c);
-      })(window, document, "script", 0, "aa");
+      })(window, document, 'script', '@@SCRIPT_SRC', 'aa');
 
       aa("init", {
         apiKey: "@@API_KEY",

--- a/examples/instantsearch/product.html
+++ b/examples/instantsearch/product.html
@@ -1,18 +1,19 @@
 <html>
   <head>
     <script>
-      (function(i, s, o, g, r, a, m) {
-        i["AlgoliaAnalyticsObject"] = r;
-        i[r] =
-          i[r] ||
-          function() {
-            (i[r].queue = i[r].queue || []).push(arguments);
-          };
-        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m);
-      })(window, document, "script", "@@SCRIPT_SRC", "aa");
+      !(function (e, a, t, n, s, i, c) {
+        (e.AlgoliaAnalyticsObject = s),
+          (e[s] =
+            e[s] ||
+            function () {
+              (e[s].queue = e[s].queue || []).push(arguments);
+            }),
+          (i = a.createElement(t)),
+          (c = a.getElementsByTagName(t)[0]),
+          (i.async = 1),
+          (i.src = n),
+          c.parentNode.insertBefore(i, c);
+      })(window, document, 'script', '@@SCRIPT_SRC', 'aa');
 
       aa("init", {
         apiKey: "@@API_KEY",

--- a/lib/__tests__/_createInsightsClient.test.ts
+++ b/lib/__tests__/_createInsightsClient.test.ts
@@ -1,32 +1,32 @@
-import { createInsightsClient } from '../_createInsightsClient';
+import { createInsightsClient } from "../_createInsightsClient";
 
-describe('createInsightsClient', () => {
+describe("createInsightsClient", () => {
   beforeEach(() => {
     window.AlgoliaAnalyticsObject = undefined;
   });
 
-  it('should return a function', () => {
-    expect(typeof createInsightsClient(() => {})).toBe('function');
+  it("should return a function", () => {
+    expect(typeof createInsightsClient(() => {})).toBe("function");
   });
 
-  it('registers itself to window', () => {
+  it("registers itself to window", () => {
     const aa = createInsightsClient(() => {});
 
-    expect(typeof window.AlgoliaAnalyticsObject).toBe('string');
+    expect(typeof window.AlgoliaAnalyticsObject).toBe("string");
     expect(window[window.AlgoliaAnalyticsObject!]).toBe(aa);
   });
 
   it("doesn't register itself to window if key is already taken", () => {
-    window.AlgoliaAnalyticsObject = 'existingKey';
+    window.AlgoliaAnalyticsObject = "existingKey";
     const aa = createInsightsClient(() => {});
 
-    expect(window.AlgoliaAnalyticsObject).toBe('existingKey');
+    expect(window.AlgoliaAnalyticsObject).toBe("existingKey");
     expect(window[window.AlgoliaAnalyticsObject!]).not.toBe(aa);
   });
 
   it("doesn't register if no window", () => {
     delete (global as any).window;
 
-    expect(typeof createInsightsClient(() => {})).toBe('function');
+    expect(typeof createInsightsClient(() => {})).toBe("function");
   });
 });

--- a/lib/__tests__/_createInsightsClient.test.ts
+++ b/lib/__tests__/_createInsightsClient.test.ts
@@ -1,0 +1,32 @@
+import { createInsightsClient } from '../_createInsightsClient';
+
+describe('createInsightsClient', () => {
+  beforeEach(() => {
+    window.AlgoliaAnalyticsObject = undefined;
+  });
+
+  it('should return a function', () => {
+    expect(typeof createInsightsClient(() => {})).toBe('function');
+  });
+
+  it('registers itself to window', () => {
+    const aa = createInsightsClient(() => {});
+
+    expect(typeof window.AlgoliaAnalyticsObject).toBe('string');
+    expect(window[window.AlgoliaAnalyticsObject!]).toBe(aa);
+  });
+
+  it("doesn't register itself to window if key is already taken", () => {
+    window.AlgoliaAnalyticsObject = 'existingKey';
+    const aa = createInsightsClient(() => {});
+
+    expect(window.AlgoliaAnalyticsObject).toBe('existingKey');
+    expect(window[window.AlgoliaAnalyticsObject!]).not.toBe(aa);
+  });
+
+  it("doesn't register if no window", () => {
+    delete (global as any).window;
+
+    expect(typeof createInsightsClient(() => {})).toBe('function');
+  });
+});

--- a/lib/_createInsightsClient.ts
+++ b/lib/_createInsightsClient.ts
@@ -1,7 +1,21 @@
-import AlgoliaAnalytics from "./insights";
-import { getFunctionalInterface } from "./_getFunctionalInterface";
-import { RequestFnType } from "./utils/request";
+import AlgoliaAnalytics from './insights';
+import { getFunctionalInterface } from './_getFunctionalInterface';
+import { RequestFnType } from './utils/request';
+import { createUUID } from './utils/uuid';
 
 export function createInsightsClient(requestFn: RequestFnType) {
-  return getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));
+  const aa = getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));
+
+  if (typeof window === 'object') {
+    if (!window.AlgoliaAnalyticsObject) {
+      let pointer: string;
+      do {
+        pointer = createUUID();
+      } while (window[pointer] !== undefined);
+      window.AlgoliaAnalyticsObject = pointer;
+      window[window.AlgoliaAnalyticsObject] = aa;
+    }
+  }
+
+  return aa;
 }

--- a/lib/entry-umd.ts
+++ b/lib/entry-umd.ts
@@ -5,7 +5,7 @@ import { RequestFnType } from "./utils/request";
 
 export function createInsightsClient(requestFn: RequestFnType) {
   const instance = new AlgoliaAnalytics({ requestFn });
-  if (typeof window !== "undefined") {
+  if (typeof window === 'object') {
     // Process queue upon script execution
     processQueue.call(instance, window);
   }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -39,11 +39,11 @@ type AnalyticsFunction = {
   [key: string]: (fnName: string, fnArgs: any[]) => void;
 };
 
-type AlgoliaAnalyticsObject = Queue | AnalyticsFunction;
+export type AlgoliaAnalyticsObject = Queue | AnalyticsFunction;
 
 declare global {
   interface Window {
-    AlgoliaAnalyticsObject: AlgoliaAnalyticsObject;
+    AlgoliaAnalyticsObject?: string;
   }
 }
 


### PR DESCRIPTION
This allows us to detect a search-insights instance, regardless of whether it's using umd or cjs entry points.

FX-2264