### PR TITLE
feat(v2): allow to `init` again while preserving passed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ aa('setUserToken', 'USER_ID');
 | `cookieDuration`  | `number`       | `15552000000` (6 months) | The cookie duration in milliseconds            |
 | `userToken`       | `string`       | `undefined` (optional)   | Initial userToken. When given, anonymous userToken will not be set. |
 
+To update the client with new options, you can call `init` again.
+
+By default, all previously passed options that you don't redefine are reset to their default setting, except for the `userToken`. To preserve previously passed options without redeclaring them, use the `patch` option.
+
+```js
+aa("init", {
+  appId: "APP_ID",
+  apiKey: "SEARCH_API_KEY",
+  region: "de",
+});
+
+aa("init", {
+  appId: "APP_ID",
+  apiKey: "SEARCH_API_KEY",
+  patch: true,
+}); // `region` is still `"de"`
+```
+
 ##### Note for Require.js users
 
 When using [Require.js](https://requirejs.org/), the default UMD build might conflict and throw with a "Mismatched anonymous define() modules" message. This is a [known Require.js issue](https://requirejs.org/docs/errors.html#mismatch).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ aa("init", {
 aa("init", {
   appId: "APP_ID",
   apiKey: "SEARCH_API_KEY",
-  patch: true,
+  partial: true,
 }); // `region` is still `"de"`
 ```
 

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -225,7 +225,7 @@ describe("init", () => {
     // Custom user token isn't reset on `init` if not provided
     expect(analyticsInstance._userToken).toBe("myUserToken");
   });
-  it("should not merge with previous options when `patch` is `false`", () => {
+  it("should not merge with previous options when `partial` is `false`", () => {
     analyticsInstance.init({
       apiKey: "apiKey1",
       appId: "appId1",
@@ -247,7 +247,7 @@ describe("init", () => {
     analyticsInstance.init({
       apiKey: "apiKey2",
       appId: "appId2",
-      patch: false
+      partial: false
     });
 
     expect(analyticsInstance._appId).toBe("appId2");
@@ -259,7 +259,7 @@ describe("init", () => {
     // The user token isn't reset on `init` when not provided
     expect(analyticsInstance._userToken).toBe("myUserToken");
   });
-  it("should merge with previous options when `patch` is `true`", () => {
+  it("should merge with previous options when `partial` is `true`", () => {
     analyticsInstance.init({
       apiKey: "apiKey1",
       appId: "appId1",
@@ -278,7 +278,11 @@ describe("init", () => {
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
 
-    analyticsInstance.init({ apiKey: "apiKey2", appId: "appId2", patch: true });
+    analyticsInstance.init({
+      apiKey: "apiKey2",
+      appId: "appId2",
+      partial: true
+    });
 
     expect(analyticsInstance._appId).toBe("appId2");
     expect(analyticsInstance._apiKey).toBe("apiKey2");

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -81,7 +81,7 @@ describe("init", () => {
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    cookieDuration => {
+    (cookieDuration) => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -423,7 +423,7 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", done => {
+    it("can set userToken manually afterwards", (done) => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -81,7 +81,7 @@ describe("init", () => {
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    (cookieDuration) => {
+    cookieDuration => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -423,7 +423,7 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", (done) => {
+    it("can set userToken manually afterwards", done => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -13,6 +13,7 @@ export interface InitParams {
   cookieDuration?: number;
   region?: InsightRegion;
   userToken?: string;
+  patch?: boolean;
 }
 
 /**
@@ -63,15 +64,22 @@ You can visit https://algolia.com/events/debugger instead.`);
 
   this._apiKey = options.apiKey;
   this._appId = options.appId;
-  this._userHasOptedOut = !!options.userHasOptedOut;
-  this._region = options.region;
+
+  this._userHasOptedOut = options.patch
+    ? patchOption(options.userHasOptedOut, this._userHasOptedOut)
+    : !!options.userHasOptedOut;
+  this._region = options.patch
+    ? patchOption(options.region, this._region)
+    : options.region;
   this._endpointOrigin = options.region
     ? `https://insights.${options.region}.algolia.io`
     : "https://insights.algolia.io";
-  this._useCookie = options.useCookie ?? false;
-  this._cookieDuration = options.cookieDuration
-    ? options.cookieDuration
-    : 6 * MONTH;
+  this._useCookie = options.patch
+    ? patchOption(options.useCookie, this._useCookie)
+    : options.useCookie ?? false;
+  this._cookieDuration = options.patch
+    ? patchOption(options.cookieDuration, this._cookieDuration)
+    : options.cookieDuration || 6 * MONTH;
   // Set hasCredentials
   this._hasCredentials = true;
 
@@ -83,4 +91,8 @@ You can visit https://algolia.com/events/debugger instead.`);
   } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
   }
+}
+
+function patchOption<TOption>(option: TOption, fallback: TOption) {
+  return isUndefined(option) ? fallback : option;
 }

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -16,7 +16,7 @@ export interface InitParams {
   cookieDuration?: number;
   region?: InsightRegion;
   userToken?: string;
-  patch?: boolean;
+  partial?: boolean;
 }
 
 /**
@@ -101,10 +101,10 @@ type ThisParams = {
 
 function setOptions(
   target: ThisParams,
-  { patch, ...options }: InitParams,
+  { partial: partial, ...options }: InitParams,
   defaultValues: ThisParams
 ) {
-  if (!patch) {
+  if (!partial) {
     Object.assign(target, defaultValues);
   }
 

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -108,11 +108,11 @@ function setOptions(
     Object.assign(target, defaultValues);
   }
 
-  for (const key in options) {
-    const newValue = options[key];
-
-    if (!isUndefined(newValue)) {
-      target[`_${key}`] = newValue;
-    }
-  }
+  Object.assign(
+    target,
+    Object.keys(options).reduce(
+      (acc, key) => ({ ...acc, [`_${key}`]: options[key] }),
+      {}
+    )
+  );
 }


### PR DESCRIPTION
This introduces a ~~`patch`~~ `partial` option in the `init` method which lets you update only the options that you declare, without resetting the others.

If this works for us, we can backport this in v1, and have it implemented in the upcoming v3.