### PR TITLE
feat(v1): allow to `init` again while preserving passed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ aa('init', {
 });
 ```
 
+To update the client with new options, you can call `init` again.
+
+By default, all previously passed options that you don't redefine are reset to their default setting, except for the `userToken`. To preserve previously passed options without redeclaring them, use the `patch` option.
+
+```js
+aa("init", {
+  appId: 'APPLICATION_ID',
+  apiKey: "SEARCH_API_KEY",
+  region: "de",
+});
+aa("init", {
+  appId: 'APPLICATION_ID',
+  apiKey: "SEARCH_API_KEY",
+  partial: true,
+}); // `region` is still `"de"`
+```
+
 #### Add `userToken`
 
 On the Node.js environment, unlike the browser environment, `userToken` must be specified when sending any event.

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -81,7 +81,7 @@ describe("init", () => {
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    (cookieDuration) => {
+    cookieDuration => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -418,12 +418,12 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", (done) => {
+    it("can set userToken manually afterwards", done => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);
       expect(setUserToken).toHaveBeenLastCalledWith("def");
-      analyticsInstance._get("_userToken", (value) => {
+      analyticsInstance._get("_userToken", value => {
         expect(value).toEqual("def");
         done();
       });

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -81,7 +81,7 @@ describe("init", () => {
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    cookieDuration => {
+    (cookieDuration) => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -188,6 +188,106 @@ describe("init", () => {
     expect(setUserToken).toHaveBeenCalledTimes(2);
 
     setUserToken.mockRestore();
+  });
+
+  it("should replace existing options when called again", () => {
+    analyticsInstance.init({
+      apiKey: "apiKey1",
+      appId: "appId1",
+      region: "de",
+      userHasOptedOut: true,
+      useCookie: false,
+      cookieDuration: 100,
+      userToken: "myUserToken"
+    });
+
+    expect(analyticsInstance._appId).toBe("appId1");
+    expect(analyticsInstance._apiKey).toBe("apiKey1");
+    expect(analyticsInstance._region).toBe("de");
+    expect(analyticsInstance._userHasOptedOut).toBe(true);
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(100);
+    expect(analyticsInstance._userToken).toBe("myUserToken");
+
+    analyticsInstance.init({ apiKey: "apiKey2", appId: "appId2" });
+
+    expect(analyticsInstance._appId).toBe("appId2");
+    expect(analyticsInstance._apiKey).toBe("apiKey2");
+    expect(analyticsInstance._region).toBe(undefined);
+    expect(analyticsInstance._userHasOptedOut).toBe(false);
+    expect(analyticsInstance._useCookie).toBe(true);
+    expect(analyticsInstance._cookieDuration).toBe(15552000000);
+    // Custom user token isn't reset on `init` if not provided
+    expect(analyticsInstance._userToken).toBe("myUserToken");
+  });
+
+  it("should not merge with previous options when `partial` is `false`", () => {
+    analyticsInstance.init({
+      apiKey: "apiKey1",
+      appId: "appId1",
+      region: "de",
+      userHasOptedOut: true,
+      useCookie: false,
+      cookieDuration: 100,
+      userToken: "myUserToken"
+    });
+
+    expect(analyticsInstance._appId).toBe("appId1");
+    expect(analyticsInstance._apiKey).toBe("apiKey1");
+    expect(analyticsInstance._region).toBe("de");
+    expect(analyticsInstance._userHasOptedOut).toBe(true);
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(100);
+    expect(analyticsInstance._userToken).toBe("myUserToken");
+
+    analyticsInstance.init({
+      apiKey: "apiKey2",
+      appId: "appId2",
+      partial: false
+    });
+
+    expect(analyticsInstance._appId).toBe("appId2");
+    expect(analyticsInstance._apiKey).toBe("apiKey2");
+    expect(analyticsInstance._region).toBe(undefined);
+    expect(analyticsInstance._userHasOptedOut).toBe(false);
+    expect(analyticsInstance._useCookie).toBe(true);
+    expect(analyticsInstance._cookieDuration).toBe(15552000000);
+    // The user token isn't reset on `init` when not provided
+    expect(analyticsInstance._userToken).toBe("myUserToken");
+  });
+
+  it("should merge with previous options when `partial` is `true`", () => {
+    analyticsInstance.init({
+      apiKey: "apiKey1",
+      appId: "appId1",
+      region: "de",
+      userHasOptedOut: true,
+      useCookie: false,
+      cookieDuration: 100,
+      userToken: "myUserToken"
+    });
+
+    expect(analyticsInstance._appId).toBe("appId1");
+    expect(analyticsInstance._apiKey).toBe("apiKey1");
+    expect(analyticsInstance._region).toBe("de");
+    expect(analyticsInstance._userHasOptedOut).toBe(true);
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(100);
+    expect(analyticsInstance._userToken).toBe("myUserToken");
+
+    analyticsInstance.init({
+      apiKey: "apiKey2",
+      appId: "appId2",
+      partial: true
+    });
+
+    expect(analyticsInstance._appId).toBe("appId2");
+    expect(analyticsInstance._apiKey).toBe("apiKey2");
+    expect(analyticsInstance._region).toBe("de");
+    expect(analyticsInstance._userHasOptedOut).toBe(true);
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(100);
+    expect(analyticsInstance._userToken).toBe("myUserToken");
   });
 
   describe("callback for userToken", () => {
@@ -318,12 +418,12 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", done => {
+    it("can set userToken manually afterwards", (done) => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);
       expect(setUserToken).toHaveBeenLastCalledWith("def");
-      analyticsInstance._get("_userToken", value => {
+      analyticsInstance._get("_userToken", (value) => {
         expect(value).toEqual("def");
         done();
       });

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,5 +1,8 @@
 import { isUndefined, isString, isNumber } from "./utils";
 import { DEFAULT_ALGOLIA_AGENT } from "./_algoliaAgent";
+import objectAssignPolyfill from "./polyfills/objectAssign";
+
+objectAssignPolyfill();
 
 type InsightRegion = "de" | "us";
 const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
@@ -13,6 +16,7 @@ export interface InitParams {
   cookieDuration?: number;
   region?: InsightRegion;
   userToken?: string;
+  partial?: boolean;
 }
 
 /**
@@ -58,15 +62,18 @@ export function init(options: InitParams) {
 
   this._apiKey = options.apiKey;
   this._appId = options.appId;
-  this._userHasOptedOut = !!options.userHasOptedOut;
-  this._region = options.region;
+
+  setOptions(this, options, {
+    _userHasOptedOut: !!options.userHasOptedOut,
+    _region: options.region,
+    _useCookie: options.useCookie ?? true,
+    _cookieDuration: options.cookieDuration || 6 * MONTH
+  });
+
   this._endpointOrigin = options.region
     ? `https://insights.${options.region}.algolia.io`
     : "https://insights.algolia.io";
-  this._useCookie = options.useCookie ?? true;
-  this._cookieDuration = options.cookieDuration
-    ? options.cookieDuration
-    : 6 * MONTH;
+
   // Set hasCredentials
   this._hasCredentials = true;
 
@@ -79,4 +86,29 @@ export function init(options: InitParams) {
   } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
   }
+}
+
+type ThisParams = {
+  _userHasOptedOut: InitParams["userHasOptedOut"];
+  _useCookie: InitParams["useCookie"];
+  _cookieDuration: InitParams["cookieDuration"];
+  _region: InitParams["region"];
+};
+
+function setOptions(
+  target: ThisParams,
+  { partial: partial, ...options }: InitParams,
+  defaultValues: ThisParams
+) {
+  if (!partial) {
+    Object.assign(target, defaultValues);
+  }
+
+  Object.assign(
+    target,
+    Object.keys(options).reduce(
+      (acc, key) => ({ ...acc, [`_${key}`]: options[key] }),
+      {}
+    )
+  );
 }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   "bundlesize": [
     {
       "path": "./dist/search-insights.min.js",
-      "maxSize": "3.05 kB"
+      "maxSize": "3.25 kB"
     }
   ]
 }


### PR DESCRIPTION
This introduces a `partial` option in the `init` method which lets you update only the options that you declare, without resetting the others.

Related: https://github.com/algolia/search-insights.js/pull/401