### PR TITLE
chore: update reviewers for shipjs release pr

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 module.exports = {
   buildCommand: () => "yarn build && /bin/bash ./pre-deploy.sh",
-  pullRequestTeamReviewers: ["@algolia/instantsearch-for-websites"],
+  pullRequestTeamReviewers: ["frontend-experiences-web"],
   versionUpdated: ({ version, releaseType, dir }) => {
     if (
       releaseType === "major" ||


### PR DESCRIPTION
Quick PR to attribute the correct reviewer group to ShipJS release pull requests, which in its current state throws an error during the prepare process.