### PR TITLE
feat: expose version string from functional interface

### DIFF
--- a/lib/__tests__/_createInsightsClient.test.ts
+++ b/lib/__tests__/_createInsightsClient.test.ts
@@ -1,4 +1,5 @@
 import { createInsightsClient } from "../_createInsightsClient";
+import { version } from "../../package.json";
 
 describe("createInsightsClient", () => {
   beforeEach(() => {
@@ -7,6 +8,12 @@ describe("createInsightsClient", () => {
 
   it("should return a function", () => {
     expect(typeof createInsightsClient(() => {})).toBe("function");
+  });
+
+  it("returns its version number", () => {
+    const aa = createInsightsClient(() => {});
+
+    expect(aa.version).toEqual(version);
   });
 
   it("registers itself to window", () => {

--- a/lib/_createInsightsClient.ts
+++ b/lib/_createInsightsClient.ts
@@ -1,12 +1,13 @@
-import AlgoliaAnalytics from './insights';
-import { getFunctionalInterface } from './_getFunctionalInterface';
-import { RequestFnType } from './utils/request';
-import { createUUID } from './utils/uuid';
+import AlgoliaAnalytics from "./insights";
+import { getFunctionalInterface } from "./_getFunctionalInterface";
+import { RequestFnType } from "./utils/request";
+import { createUUID } from "./utils/uuid";
+import { version } from "../package.json";
 
 export function createInsightsClient(requestFn: RequestFnType) {
   const aa = getFunctionalInterface(new AlgoliaAnalytics({ requestFn }));
 
-  if (typeof window === 'object') {
+  if (typeof window === "object") {
     if (!window.AlgoliaAnalyticsObject) {
       let pointer: string;
       do {
@@ -16,6 +17,8 @@ export function createInsightsClient(requestFn: RequestFnType) {
       window[window.AlgoliaAnalyticsObject] = aa;
     }
   }
+
+  aa.version = version;
 
   return aa;
 }

--- a/lib/entry-umd.ts
+++ b/lib/entry-umd.ts
@@ -2,13 +2,16 @@ import AlgoliaAnalytics from "./insights";
 import { getRequesterForBrowser } from "./utils/getRequesterForBrowser";
 import { processQueue } from "./_processQueue";
 import { RequestFnType } from "./utils/request";
+import { version } from "../package.json";
 
 export function createInsightsClient(requestFn: RequestFnType) {
   const instance = new AlgoliaAnalytics({ requestFn });
-  if (typeof window === 'object') {
+  if (typeof window === "object") {
     // Process queue upon script execution
     processQueue.call(instance, window);
   }
+
+  instance.version = version;
   return instance;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -94,7 +94,9 @@ export type InsightsClient = Init &
   ConvertedObjectIDs &
   ConvertedFilters &
   ViewedObjectIDs &
-  ViewedFilters;
+  ViewedFilters & {
+    version?: string;
+  };
 
 export type InsightsAdditionalEventParams = {
   headers?: Record<string, string>;


### PR DESCRIPTION
This PR exposes a `version` property on the functional interface that is provided either through UMD or CJS bundles.

Combined with an updated snippet that also provides this in the temporary queue structure, it will help consumers reliably determine the version of the search-insights library before it is even loaded (in the case of UMD).