### PR TITLE
feat: allow to `init` without credentials (v2)

### DIFF
--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -246,6 +246,34 @@ describe("sendEvents", () => {
       ]);
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(0);
     });
+
+    it.only("applies constructor default values when `init` is not called", () => {
+      const customAppId = "overrideTestId";
+      const customApiKey = "overrideTestKey";
+
+      analyticsInstance = setupInstance({ init: false });
+      analyticsInstance.sendEvents(
+        [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"]
+          }
+        ],
+        {
+          headers: {
+            "X-Algolia-Application-Id": customAppId,
+            "X-Algolia-API-Key": customApiKey
+          }
+        }
+      );
+
+      expect(analyticsInstance._endpointOrigin).toBe(
+        "https://insights.algolia.io"
+      );
+      expect(analyticsInstance._userHasOptedOut).toBe(false);
+    });
   });
 
   describe("objectIDs and positions", () => {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -12,9 +12,12 @@ const credentials = {
   appId: "testId"
 };
 
-function setupInstance(requestFn = getRequesterForBrowser()) {
+function setupInstance({
+  requestFn = getRequesterForBrowser(),
+  init = true
+} = {}) {
   const instance = new AlgoliaAnalytics({ requestFn });
-  instance.init(credentials);
+  if (init) instance.init(credentials);
   instance.setUserToken("mock-user-id");
   return instance;
 }
@@ -39,6 +42,7 @@ describe("sendEvents", () => {
     let sendBeaconBackup;
     beforeEach(() => {
       sendBeaconBackup = window.navigator.sendBeacon;
+      // @ts-expect-error
       window.navigator.sendBeacon = undefined; // force usage of XMLHttpRequest
       analyticsInstance = setupInstance();
     });
@@ -179,7 +183,7 @@ describe("sendEvents", () => {
 
     beforeEach(() => {
       fakeRequestFn.mockClear();
-      analyticsInstance = setupInstance(fakeRequestFn);
+      analyticsInstance = setupInstance({ requestFn: fakeRequestFn });
     });
     it("should call the requestFn with expected arguments", () => {
       (analyticsInstance as any).sendEvents([
@@ -230,14 +234,6 @@ describe("sendEvents", () => {
       analyticsInstance = setupInstance();
     });
 
-    it("should throw if init was not called", () => {
-      expect(() => {
-        (analyticsInstance as any)._hasCredentials = false;
-        (analyticsInstance as any).sendEvents();
-      }).toThrowError(
-        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
-      );
-    });
     it("should do nothing is _userHasOptedOut === true", () => {
       analyticsInstance._userHasOptedOut = true;
       (analyticsInstance as any).sendEvents([
@@ -422,7 +418,7 @@ describe("sendEvents", () => {
 
     beforeEach(() => {
       fakeRequestFn.mockClear();
-      analyticsInstance = setupInstance(fakeRequestFn);
+      analyticsInstance = setupInstance({ requestFn: fakeRequestFn });
     });
 
     it("should send multiple events via clickedObjectIDs", () => {
@@ -502,6 +498,30 @@ describe("sendEvents", () => {
     });
   });
 
+  it("applies default credentials when no custom ones are provided", () => {
+    const analyticsInstance = setupInstance();
+
+    analyticsInstance.sendEvents([
+      {
+        eventType: "click",
+        eventName: "my-event",
+        index: "my-index",
+        objectIDs: ["1"]
+      }
+    ]);
+
+    {
+      const requestUrl = XMLHttpRequest.open.mock.calls[0][1];
+      const { query } = url.parse(requestUrl);
+      expect(querystring.parse(query!)).toMatchObject(
+        expect.objectContaining({
+          "X-Algolia-Application-Id": credentials.appId,
+          "X-Algolia-API-Key": credentials.apiKey
+        })
+      );
+    }
+  });
+
   it("applies custom credentials when provided", () => {
     const analyticsInstance = setupInstance();
 
@@ -556,5 +576,22 @@ describe("sendEvents", () => {
         })
       );
     }
+  });
+
+  it("should throw if no default or custom credentials are provided", () => {
+    const analyticsInstance = setupInstance({ init: false });
+
+    expect(() => {
+      analyticsInstance.sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or have custom credentials in additional parameters."`
+    );
   });
 });

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -591,7 +591,7 @@ describe("sendEvents", () => {
         }
       ]);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or have custom credentials in additional parameters."`
+      `"Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or provide custom credentials in additional parameters."`
     );
   });
 });

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -247,7 +247,7 @@ describe("sendEvents", () => {
       expect(XMLHttpRequest.send).toHaveBeenCalledTimes(0);
     });
 
-    it.only("applies constructor default values when `init` is not called", () => {
+    it("applies constructor default values when `init` is not called", () => {
       const customAppId = "overrideTestId";
       const customApiKey = "overrideTestKey";
 

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -18,31 +18,10 @@ describe("Library initialisation", () => {
     analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
   });
 
-  it("Should throw if there is no apiKey and appId", () => {
+  it("Should not throw if there is no apiKey and appId", () => {
     expect(() => {
-      // @ts-ignore
       analyticsInstance.init();
-    }).toThrowError(
-      "Init function should be called with an object argument containing your apiKey and appId"
-    );
-  });
-
-  it("Should throw if there is only apiKey param", () => {
-    expect(() => {
-      // @ts-ignore
-      analyticsInstance.init({ apiKey: "1234" });
-    }).toThrow(
-      "appId is missing, please provide it, so we can properly attribute data to your application"
-    );
-  });
-
-  it("Should throw if there is only applicatioID param", () => {
-    expect(() => {
-      // @ts-ignore
-      analyticsInstance.init({ appId: "1234" });
-    }).toThrow(
-      "apiKey is missing, please provide it so we can authenticate the application"
-    );
+    }).not.toThrowError();
   });
 
   it("Should not throw if all params are set", () => {

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -31,9 +31,6 @@ describe("Library initialisation", () => {
         appId: "ABCD"
       });
     }).not.toThrow();
-
-    // @ts-ignore private prop
-    expect(analyticsInstance._hasCredentials).toBe(true);
   });
 
   it("Should create UUID", () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -1,6 +1,6 @@
 import AlgoliaAnalytics from "../insights";
 import * as utils from "../utils";
-import { getCookie } from "../_tokenUtils";
+import { getCookie, MONTH } from "../_tokenUtils";
 
 describe("init", () => {
   let analyticsInstance: AlgoliaAnalytics;
@@ -60,12 +60,11 @@ describe("init", () => {
   });
   it("should use 6 months cookieDuration by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
-    const month = 30 * 24 * 60 * 60 * 1000;
-    expect(analyticsInstance._cookieDuration).toBe(6 * month);
+    expect(analyticsInstance._cookieDuration).toBe(6 * MONTH);
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    cookieDuration => {
+    (cookieDuration) => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -84,6 +83,15 @@ describe("init", () => {
       cookieDuration: 42
     });
     expect(analyticsInstance._cookieDuration).toBe(42);
+  });
+  it("should set cookie parameters if defined in `init`", () => {
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(6 * MONTH);
+
+    analyticsInstance.init({ useCookie: true, cookieDuration: MONTH })
+
+    expect(analyticsInstance._useCookie).toBe(true);
+    expect(analyticsInstance._cookieDuration).toBe(MONTH);
   });
   it("should set _endpointOrigin on instance to https://insights.algolia.io", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
@@ -419,7 +427,7 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", done => {
+    it("can set userToken manually afterwards", (done) => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -64,7 +64,7 @@ describe("init", () => {
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
-    (cookieDuration) => {
+    cookieDuration => {
       expect(() => {
         (analyticsInstance as any).init({
           cookieDuration,
@@ -88,7 +88,7 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(false);
     expect(analyticsInstance._cookieDuration).toBe(6 * MONTH);
 
-    analyticsInstance.init({ useCookie: true, cookieDuration: MONTH })
+    analyticsInstance.init({ useCookie: true, cookieDuration: MONTH });
 
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(MONTH);
@@ -427,7 +427,7 @@ describe("init", () => {
       expect(setAnonymousUserToken).not.toHaveBeenCalled();
     });
 
-    it("can set userToken manually afterwards", (done) => {
+    it("can set userToken manually afterwards", done => {
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -275,15 +275,6 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
-  });
-  it("should merge with previous credentials when `partial` is `true`", () => {
-    analyticsInstance.init({
-      appId: "appId1",
-      apiKey: "apiKey1"
-    });
-
-    expect(analyticsInstance._appId).toBe("appId1");
-    expect(analyticsInstance._apiKey).toBe("apiKey1");
 
     analyticsInstance.init({
       appId: "appId2",
@@ -291,7 +282,7 @@ describe("init", () => {
     });
 
     expect(analyticsInstance._appId).toBe("appId2");
-    expect(analyticsInstance._apiKey).toBe("apiKey1");
+    expect(analyticsInstance._apiKey).toBe("apiKey2");
   });
 
   describe("callback for userToken", () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -9,26 +9,10 @@ describe("init", () => {
     document.cookie = `_ALGOLIA=;${new Date().toUTCString()};path=/`;
   });
 
-  it("should throw if no parameters is passed", () => {
+  it("should not throw if no parameters are passed", () => {
     expect(() => {
       (analyticsInstance as any).init();
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"Init function should be called with an object argument containing your apiKey and appId"`
-    );
-  });
-  it("should throw if apiKey is not sent", () => {
-    expect(() => {
-      (analyticsInstance as any).init({ appId: "***" });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"apiKey is missing, please provide it so we can authenticate the application"`
-    );
-  });
-  it("should throw if appId is not sent", () => {
-    expect(() => {
-      (analyticsInstance as any).init({ apiKey: "***" });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"appId is missing, please provide it, so we can properly attribute data to your application"`
-    );
+    }).not.toThrowError();
   });
   it("should throw if region is other than `de` | `us`", () => {
     expect(() => {
@@ -291,6 +275,23 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+  });
+  it("should merge with previous credentials when `partial` is `true`", () => {
+    analyticsInstance.init({
+      appId: "appId1",
+      apiKey: "apiKey1"
+    });
+
+    expect(analyticsInstance._appId).toBe("appId1");
+    expect(analyticsInstance._apiKey).toBe("apiKey1");
+
+    analyticsInstance.init({
+      appId: "appId2",
+      partial: true
+    });
+
+    expect(analyticsInstance._appId).toBe("appId2");
+    expect(analyticsInstance._apiKey).toBe("apiKey1");
   });
 
   describe("callback for userToken", () => {

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -15,7 +15,7 @@ export function makeSendEvents(requestFn: RequestFnType) {
       additionalParams?.headers["X-Algolia-API-Key"];
     if (!this._hasCredentials && !hasCustomCredentials) {
       throw new Error(
-        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or have custom credentials in additional parameters."
+        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or provide custom credentials in additional parameters."
       );
     }
 

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -10,9 +10,12 @@ export function makeSendEvents(requestFn: RequestFnType) {
     if (this._userHasOptedOut) {
       return;
     }
-    if (!this._hasCredentials) {
+    const hasCustomCredentials =
+      additionalParams?.headers["X-Algolia-Application-Id"] &&
+      additionalParams?.headers["X-Algolia-API-Key"];
+    if (!this._hasCredentials && !hasCustomCredentials) {
       throw new Error(
-        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
+        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or have custom credentials in additional parameters."
       );
     }
 

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -10,10 +10,11 @@ export function makeSendEvents(requestFn: RequestFnType) {
     if (this._userHasOptedOut) {
       return;
     }
-    const hasCustomCredentials =
-      additionalParams?.headers["X-Algolia-Application-Id"] &&
-      additionalParams?.headers["X-Algolia-API-Key"];
-    if (!this._hasCredentials && !hasCustomCredentials) {
+    const hasCredentials =
+      (!isUndefined(this._apiKey) && !isUndefined(this._appId)) ||
+      (additionalParams?.headers["X-Algolia-Application-Id"] &&
+        additionalParams?.headers["X-Algolia-API-Key"]);
+    if (!hasCredentials) {
       throw new Error(
         "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or provide custom credentials in additional parameters."
       );

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -2,6 +2,7 @@ import { createUUID } from "./utils/uuid";
 import { isFunction, supportsCookies } from "./utils";
 
 const COOKIE_KEY = "_ALGOLIA";
+export const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 const setCookie = (name: string, value: number | string, duration: number) => {
   const d = new Date();

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -61,10 +61,6 @@ You can visit https://algolia.com/events/debugger instead.`);
     ? `https://insights.${options.region}.algolia.io`
     : "https://insights.algolia.io";
 
-  // Set hasCredentials
-  this._hasCredentials =
-    !isUndefined(this._apiKey) && !isUndefined(this._appId);
-
   // user agent
   this._ua = [...DEFAULT_ALGOLIA_AGENTS];
 

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,12 +1,12 @@
 import { isUndefined, isNumber } from "./utils";
 import { DEFAULT_ALGOLIA_AGENTS } from "./_algoliaAgent";
 import objectAssignPolyfill from "./polyfills/objectAssign";
+import { MONTH } from "./_tokenUtils";
 
 objectAssignPolyfill();
 
 type InsightRegion = "de" | "us";
 const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
-const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 export interface InitParams {
   apiKey?: string;

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,4 +1,4 @@
-import { isUndefined, isString, isNumber } from "./utils";
+import { isUndefined, isNumber } from "./utils";
 import { DEFAULT_ALGOLIA_AGENTS } from "./_algoliaAgent";
 import objectAssignPolyfill from "./polyfills/objectAssign";
 
@@ -9,8 +9,8 @@ const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
 const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 export interface InitParams {
-  apiKey: string;
-  appId: string;
+  apiKey?: string;
+  appId?: string;
   userHasOptedOut?: boolean;
   useCookie?: boolean;
   cookieDuration?: number;
@@ -23,22 +23,7 @@ export interface InitParams {
  * Binds credentials and settings to class
  * @param options: initParams
  */
-export function init(options: InitParams) {
-  if (!options) {
-    throw new Error(
-      "Init function should be called with an object argument containing your apiKey and appId"
-    );
-  }
-  if (isUndefined(options.apiKey) || !isString(options.apiKey)) {
-    throw new Error(
-      "apiKey is missing, please provide it so we can authenticate the application"
-    );
-  }
-  if (isUndefined(options.appId) || !isString(options.appId)) {
-    throw new Error(
-      "appId is missing, please provide it, so we can properly attribute data to your application"
-    );
-  }
+export function init(options: InitParams = {}) {
   if (
     !isUndefined(options.region) &&
     SUPPORTED_REGIONS.indexOf(options.region) === -1
@@ -65,9 +50,6 @@ export function init(options: InitParams) {
 You can visit https://algolia.com/events/debugger instead.`);
   }
 
-  this._apiKey = options.apiKey;
-  this._appId = options.appId;
-
   setOptions(this, options, {
     _userHasOptedOut: !!options.userHasOptedOut,
     _region: options.region,
@@ -80,7 +62,8 @@ You can visit https://algolia.com/events/debugger instead.`);
     : "https://insights.algolia.io";
 
   // Set hasCredentials
-  this._hasCredentials = true;
+  this._hasCredentials =
+    !isUndefined(this._apiKey) && !isUndefined(this._appId);
 
   // user agent
   this._ua = [...DEFAULT_ALGOLIA_AGENTS];

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -27,7 +27,8 @@ import {
   getUserToken,
   setUserToken,
   setAnonymousUserToken,
-  onUserTokenChange
+  onUserTokenChange,
+  MONTH
 } from "./_tokenUtils";
 import { version } from "../package.json";
 
@@ -57,8 +58,8 @@ class AlgoliaAnalytics {
   _endpointOrigin = "https://insights.algolia.io";
   _userToken: string;
   _userHasOptedOut = false;
-  _useCookie: boolean;
-  _cookieDuration: number;
+  _useCookie = false;
+  _cookieDuration = 6 * MONTH;
 
   // user agent
   _ua: string[] = [];

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -65,8 +65,6 @@ class AlgoliaAnalytics {
 
   version: string = version;
 
-  protected _hasCredentials: boolean = false;
-
   // Public methods
   public init: typeof init;
   public getVersion: typeof getVersion;

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -54,9 +54,9 @@ class AlgoliaAnalytics {
   _apiKey: string;
   _appId: string;
   _region: string;
-  _endpointOrigin: string;
+  _endpointOrigin = "https://insights.algolia.io";
   _userToken: string;
-  _userHasOptedOut: boolean;
+  _userHasOptedOut = false;
   _useCookie: boolean;
   _cookieDuration: number;
 


### PR DESCRIPTION
### Summary

This PR allows to `init` without credentials (`appId` and `apiKey`).

You can now pass credentials directly when sending events, so it's not always necessary to set credentials when calling `init`.

### Result

- `init` can be called without `options`, an empty `options` object or defined `options`.
- `sendEvents` will now throw an error if no credentials coming from `init` or custom ones (coming from `additionalParams`) are provided.
- `partial: true` can be used to update `appId` and/or `apiKey`.