### PR TITLE
feat: make `init` optional (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
 Initializing the library is optional, as you can specify the [credentials for each event](#sending-events-to-multiple-algolia-applications) when sending them. This gives you the flexibility to manage your Algolia credentials on a per-event basis, without having to configure them upfront.
 
 ```js
+// Optional: configure default Algolia credentials for events
 aa('init', {
-  // `appId` and `apiKey` are optional
   appId: 'APP_ID',
   apiKey: 'SEARCH_API_KEY',
 });
@@ -64,8 +64,8 @@ aa('setUserToken', 'USER_ID');
 
 | Option            | Type           | Default                  | Description                                    |
 | ----------------- | -------------- | ------------------------ | ---------------------------------------------- |
-| **`appId`**       | `string`       | None                     | The identifier of your Algolia application     |
-| **`apiKey`**      | `string`       | None                     | The search API key of your Algolia application |
+| `appId`           | `string`       | None                     | The identifier of your Algolia application     |
+| `apiKey`          | `string`       | None                     | The search API key of your Algolia application |
 | `userHasOptedOut` | `boolean`      | `false`                  | Whether to exclude users from analytics        |
 | `region`          | `'de' \| 'us'` | Automatic                | The DNS server to target                       |
 | `useCookie`       | `boolean`      | `true`                   | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
@@ -94,8 +94,8 @@ Initializing the library is optional, as you can specify the [credentials for ea
 ```js
 const aa = require('search-insights');
 
+// Optional: configure default Algolia credentials for events
 aa('init', {
-  // `appId` and `apiKey` are optional
   appId: 'APPLICATION_ID',
   apiKey: 'SEARCH_API_KEY'
 });

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ aa('setUserToken', 'USER_ID');
 | `useCookie`       | `boolean`      | `true`                   | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
 | `cookieDuration`  | `number`       | `15552000000` (6 months) | The cookie duration in milliseconds            |
 | `userToken`       | `string`       | `undefined` (optional)   | Initial userToken. When given, anonymous userToken will not be set. |
+| `partial`         | `boolean`      | `false`                  | Whether to preserve previously passed options without redeclaring them. |
 
 ### Node.js
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
 
 #### 2. Initialize the library
 
+Initializing the library is optional, as you can specify the [credentials for each event](#sending-events-to-multiple-algolia-applications) when sending them. This gives you the flexibility to manage your Algolia credentials on a per-event basis, without having to configure them upfront.
+
 ```js
 aa('init', {
+  // `appId` and `apiKey` are optional
   appId: 'APP_ID',
   apiKey: 'SEARCH_API_KEY',
 });
@@ -61,8 +64,8 @@ aa('setUserToken', 'USER_ID');
 
 | Option            | Type           | Default                  | Description                                    |
 | ----------------- | -------------- | ------------------------ | ---------------------------------------------- |
-| **`appId`**       | `string`       | None (required)          | The identifier of your Algolia application     |
-| **`apiKey`**      | `string`       | None (required)          | The search API key of your Algolia application |
+| **`appId`**       | `string`       | None                     | The identifier of your Algolia application     |
+| **`apiKey`**      | `string`       | None                     | The search API key of your Algolia application |
 | `userHasOptedOut` | `boolean`      | `false`                  | Whether to exclude users from analytics        |
 | `region`          | `'de' \| 'us'` | Automatic                | The DNS server to target                       |
 | `useCookie`       | `boolean`      | `true`                   | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
@@ -85,10 +88,13 @@ yarn add search-insights
 
 #### 2. Initialize the library
 
+Initializing the library is optional, as you can specify the [credentials for each event](#sending-events-to-multiple-algolia-applications) when sending them. This gives you the flexibility to manage your Algolia credentials on a per-event basis, without having to configure them upfront.
+
 ```js
 const aa = require('search-insights');
 
 aa('init', {
+  // `appId` and `apiKey` are optional
   appId: 'APPLICATION_ID',
   apiKey: 'SEARCH_API_KEY'
 });
@@ -96,7 +102,7 @@ aa('init', {
 
 To update the client with new options, you can call `init` again.
 
-By default, all previously passed options that you don't redefine are reset to their default setting, except for the `userToken`. To preserve previously passed options without redeclaring them, use the `patch` option.
+By default, all previously passed options that you don't redefine are reset to their default setting, except for the `userToken`. To preserve previously passed options without redeclaring them, use the `partial` option.
 
 ```js
 aa("init", {
@@ -392,7 +398,7 @@ aa('viewedFilters', {
 
 The Search Insights library sends all events to the Algolia application it has been initialized with, by default. In some cases, you might have data coming from more than one Algolia application which all need events.
 
-You can use a single instance of the Search Insights library while still customizing the Algolia credentials on a per-event basis. All click, view and conversion methods support an additional argument where you can specify credentials that will override those set during initialization.
+You can use a single instance of the Search Insights library while still customizing the Algolia credentials on a per-event basis. All click, view and conversion methods support an additional argument where you can specify credentials that will override those set during initialization (which is optional).
 
 ```js
 aa('clickedObjectIDsAfterSearch', {

--- a/lib/__tests__/get.test.ts
+++ b/lib/__tests__/get.test.ts
@@ -24,9 +24,5 @@ describe("get", () => {
     analyticsInstance._get("_region", callback);
     expect(callback).toHaveBeenCalledTimes(3);
     expect(callback).toHaveBeenCalledWith("us");
-
-    analyticsInstance._get("_hasCredentials", callback);
-    expect(callback).toHaveBeenCalledTimes(4);
-    expect(callback).toHaveBeenCalledWith(true);
   });
 });

--- a/lib/__tests__/harvest.test.ts
+++ b/lib/__tests__/harvest.test.ts
@@ -18,31 +18,10 @@ describe("Library initialisation", () => {
     analyticsInstance = new AlgoliaAnalytics({ requestFn: () => {} });
   });
 
-  it("Should throw if there is no apiKey and appId", () => {
+  it("Should not throw if there is no apiKey and appId", () => {
     expect(() => {
-      // @ts-ignore
       analyticsInstance.init();
-    }).toThrowError(
-      "Init function should be called with an object argument containing your apiKey and appId"
-    );
-  });
-
-  it("Should throw if there is only apiKey param", () => {
-    expect(() => {
-      // @ts-ignore
-      analyticsInstance.init({ apiKey: "1234" });
-    }).toThrow(
-      "appId is missing, please provide it, so we can properly attribute data to your application"
-    );
-  });
-
-  it("Should throw if there is only applicatioID param", () => {
-    expect(() => {
-      // @ts-ignore
-      analyticsInstance.init({ appId: "1234" });
-    }).toThrow(
-      "apiKey is missing, please provide it so we can authenticate the application"
-    );
+    }).not.toThrowError();
   });
 
   it("Should not throw if all params are set", () => {
@@ -52,9 +31,6 @@ describe("Library initialisation", () => {
         appId: "ABCD"
       });
     }).not.toThrow();
-
-    // @ts-ignore private prop
-    expect(analyticsInstance._hasCredentials).toBe(true);
   });
 
   it("Should create UUID", () => {
@@ -164,18 +140,6 @@ describe("Integration tests", () => {
             })
         );
         expect(userToken).toEqual("user-id-1");
-      });
-
-      it("should get _hasCredentials from the instance", async () => {
-        const hasCredentials = await page.evaluate(
-          () =>
-            new Promise((resolve, reject) => {
-              window.aa("_get", "_hasCredentials", hasCredentials => {
-                resolve(hasCredentials);
-              });
-            })
-        );
-        expect(hasCredentials).toBe(true);
       });
 
       it("should return version", async () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -1,6 +1,6 @@
 import AlgoliaAnalytics from "../insights";
 import * as utils from "../utils";
-import { getCookie } from "../_tokenUtils";
+import { getCookie, MONTH } from "../_tokenUtils";
 
 describe("init", () => {
   let analyticsInstance;
@@ -9,26 +9,10 @@ describe("init", () => {
     document.cookie = `_ALGOLIA=;${new Date().toUTCString()};path=/`;
   });
 
-  it("should throw if no parameters is passed", () => {
+  it("should not throw if no parameters are passed", () => {
     expect(() => {
       (analyticsInstance as any).init();
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"Init function should be called with an object argument containing your apiKey and appId"`
-    );
-  });
-  it("should throw if apiKey is not sent", () => {
-    expect(() => {
-      (analyticsInstance as any).init({ appId: "***" });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"apiKey is missing, please provide it so we can authenticate the application"`
-    );
-  });
-  it("should throw if appId is not sent", () => {
-    expect(() => {
-      (analyticsInstance as any).init({ apiKey: "***" });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"appId is missing, please provide it, so we can properly attribute data to your application"`
-    );
+    }).not.toThrowError();
   });
   it("should throw if region is other than `de` | `us`", () => {
     expect(() => {
@@ -76,8 +60,7 @@ describe("init", () => {
   });
   it("should use 6 months cookieDuration by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
-    const month = 30 * 24 * 60 * 60 * 1000;
-    expect(analyticsInstance._cookieDuration).toBe(6 * month);
+    expect(analyticsInstance._cookieDuration).toBe(6 * MONTH);
   });
   it.each(["not a string", 0.002, NaN])(
     "should throw if cookieDuration passed but is not an integer (eg. %s)",
@@ -100,6 +83,15 @@ describe("init", () => {
       cookieDuration: 42
     });
     expect(analyticsInstance._cookieDuration).toBe(42);
+  });
+  it("should set cookie parameters if defined in `init`", () => {
+    expect(analyticsInstance._useCookie).toBe(false);
+    expect(analyticsInstance._cookieDuration).toBe(6 * MONTH);
+
+    analyticsInstance.init({ useCookie: true, cookieDuration: MONTH });
+
+    expect(analyticsInstance._useCookie).toBe(true);
+    expect(analyticsInstance._cookieDuration).toBe(MONTH);
   });
   it("should set _endpointOrigin on instance to https://insights.algolia.io", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
@@ -288,6 +280,14 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(false);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+
+    analyticsInstance.init({
+      appId: "appId2",
+      partial: true
+    });
+
+    expect(analyticsInstance._appId).toBe("appId2");
+    expect(analyticsInstance._apiKey).toBe("apiKey2");
   });
 
   describe("callback for userToken", () => {

--- a/lib/_initSearch.ts
+++ b/lib/_initSearch.ts
@@ -1,3 +1,5 @@
+import { isUndefined } from "./utils";
+
 export interface InitSearchParams {
   getQueryID: () => string | number;
   hitsContainer: string | string[];
@@ -8,7 +10,7 @@ export interface InitSearchParams {
  * @param initParams: InitSearchParams
  */
 export function initSearch(initParams: InitSearchParams) {
-  if (!this._hasCredentials) {
+  if ((isUndefined(this._apiKey) || isUndefined(this._appId))) {
     throw new Error(
       "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
     );

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -27,9 +27,13 @@ export function makeSendEvent(requestFn: RequestFnType) {
     if (this._userHasOptedOut) {
       return;
     }
-    if (!this._hasCredentials) {
+    const hasCredentials =
+      (!isUndefined(this._apiKey) && !isUndefined(this._appId)) ||
+      (additionalParams?.headers["X-Algolia-Application-Id"] &&
+        additionalParams?.headers["X-Algolia-API-Key"]);
+    if (!hasCredentials) {
       throw new Error(
-        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
+        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters or provide custom credentials in additional parameters."
       );
     }
     if (eventData.userToken === "" || this._userToken === "") {

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -2,6 +2,7 @@ import { createUUID } from "./utils/uuid";
 import { isFunction, supportsCookies } from "./utils";
 
 const COOKIE_KEY = "_ALGOLIA";
+export const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 const setCookie = (name: string, value: number | string, duration: number) => {
   const d = new Date();

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,16 +1,16 @@
-import { isUndefined, isString, isNumber } from "./utils";
+import { isUndefined, isNumber } from "./utils";
 import { DEFAULT_ALGOLIA_AGENT } from "./_algoliaAgent";
 import objectAssignPolyfill from "./polyfills/objectAssign";
+import { MONTH } from "./_tokenUtils";
 
 objectAssignPolyfill();
 
 type InsightRegion = "de" | "us";
 const SUPPORTED_REGIONS: InsightRegion[] = ["de", "us"];
-const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 export interface InitParams {
-  apiKey: string;
-  appId: string;
+  apiKey?: string;
+  appId?: string;
   userHasOptedOut?: boolean;
   useCookie?: boolean;
   cookieDuration?: number;
@@ -23,22 +23,7 @@ export interface InitParams {
  * Binds credentials and settings to class
  * @param options: initParams
  */
-export function init(options: InitParams) {
-  if (!options) {
-    throw new Error(
-      "Init function should be called with an object argument containing your apiKey and appId"
-    );
-  }
-  if (isUndefined(options.apiKey) || !isString(options.apiKey)) {
-    throw new Error(
-      "apiKey is missing, please provide it so we can authenticate the application"
-    );
-  }
-  if (isUndefined(options.appId) || !isString(options.appId)) {
-    throw new Error(
-      "appId is missing, please provide it, so we can properly attribute data to your application"
-    );
-  }
+export function init(options: InitParams = {}) {
   if (
     !isUndefined(options.region) &&
     SUPPORTED_REGIONS.indexOf(options.region) === -1
@@ -60,9 +45,6 @@ export function init(options: InitParams) {
     );
   }
 
-  this._apiKey = options.apiKey;
-  this._appId = options.appId;
-
   setOptions(this, options, {
     _userHasOptedOut: !!options.userHasOptedOut,
     _region: options.region,
@@ -73,9 +55,6 @@ export function init(options: InitParams) {
   this._endpointOrigin = options.region
     ? `https://insights.${options.region}.algolia.io`
     : "https://insights.algolia.io";
-
-  // Set hasCredentials
-  this._hasCredentials = true;
 
   // user agent
   this._ua = DEFAULT_ALGOLIA_AGENT;

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -40,7 +40,8 @@ import {
   getUserToken,
   setUserToken,
   setAnonymousUserToken,
-  onUserTokenChange
+  onUserTokenChange,
+  MONTH
 } from "./_tokenUtils";
 import { InsightsAdditionalEventParams } from "./types";
 import { version } from "../package.json";
@@ -68,11 +69,11 @@ class AlgoliaAnalytics {
   _apiKey: string;
   _appId: string;
   _region: string;
-  _endpointOrigin: string;
+  _endpointOrigin = "https://insights.algolia.io";
   _userToken: string;
-  _userHasOptedOut: boolean;
-  _useCookie: boolean;
-  _cookieDuration: number;
+  _userHasOptedOut = false;
+  _useCookie = false;
+  _cookieDuration = 6 * MONTH;
 
   // user agent
   _ua: string = "";
@@ -84,7 +85,6 @@ class AlgoliaAnalytics {
     eventType: InsightsEventType,
     data: InsightsEvent
   ) => void;
-  protected _hasCredentials: boolean = false;
 
   // Public methods
   public init: (params: InitParams) => void;


### PR DESCRIPTION
### Summary

[FX-2282](https://algolia.atlassian.net/browse/FX-2282)

This PR makes `init` optional as you can already pass credentials directly when sending events using `sentEvent`, so it's not always necessary to set credentials when calling `init`.

### Result

- `init` can be called without `options`, an empty `options` object or defined `options`.
- `sendEvent` will now throw an error if no credentials coming from `init` or custom ones (coming from `additionalParams`) are provided.
- `partial: true` can be used to update `appId` and/or `apiKey`.
- update the README to reflect the changes.

[FX-2282]: https://algolia.atlassian.net/browse/FX-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ