### PR TITLE
ci: fix pre-deploy script

### DIFF
--- a/pre-deploy.sh
+++ b/pre-deploy.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-file_output=$(grep -oh "localhost:8080" dist/search-insights.min.js)
-file_output_insights=$(grep -oh "https://insights.algolia.io" dist/search-insights.min.js)
+file_output=$(grep -oh "localhost:8080" dist/search-insights.min.js | head -n 1)
+file_output_insights=$(grep -oh "https://insights.algolia.io" dist/search-insights.min.js | head -n 1)
 
 # echo "$file_output", "$file_output_insights"
 
 if [[ "$file_output" == "localhost:8080" ]]; then
-  echo "search-insights.js localhost address, meaning you tried to publish a dev version of the script"
+  echo "[pre-deploy.sh] search-insights.js localhost address, meaning you tried to publish a dev version of the script"
   exit 1
 elif [[ "$file_output_insights" == "https://insights.algolia.io" ]]; then
-  echo "search-insights.js has proper reporting address"
+  echo "[pre-deploy.sh] search-insights.js has proper reporting address"
   exit 0
 else
-  printf "nothing found"
+  echo "[pre-deploy.sh] nothing found"
   exit 1
 fi


### PR DESCRIPTION
The pre-deploy script checks for the presence of a local reporting address to determine whether the library has been built correctly or not. Recent developments made this script check fail as now there are 2 occurrences of this reporting address.

This PR only retrieve the first occurrence as only one is needed to make the assertion.