### PR TITLE
ci: npm publish to branch-specific latest tag

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -4,6 +4,8 @@ const path = require("path");
 module.exports = {
   buildCommand: () => "yarn build && /bin/bash ./pre-deploy.sh",
   pullRequestTeamReviewers: ["frontend-experiences-web"],
+  publishCommand: ({ defaultCommand }) =>
+    defaultCommand.replace(/latest/, "latest-1.x"),
   versionUpdated: ({ version, releaseType, dir }) => {
     if (
       releaseType === "major" ||
@@ -12,7 +14,8 @@ module.exports = {
     ) {
       const readmePath = path.resolve(dir, "README.md");
       let content = fs.readFileSync(readmePath).toString();
-      const regex = /cdn\.jsdelivr\.net\/npm\/search-insights@(\d+?\.\d+?\.\d+?)/;
+      const regex =
+        /cdn\.jsdelivr\.net\/npm\/search-insights@(\d+?\.\d+?\.\d+?)/;
       const newUrl = `cdn.jsdelivr.net/npm/search-insights@${version}`;
       content = content.replace(regex, newUrl);
       fs.writeFileSync(readmePath, content);


### PR DESCRIPTION
This PR changes the Ship.js config so that future releases of search-insights@v1 are tagged `latest-1.x` on npm, instead of polluting the `latest` tag which should be left for the actual latest version of the library.