### PR TITLE
feat(userToken): generate in-memory anonymous user tokens by default

### DIFF
--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -2,15 +2,8 @@
  * @jest-environment node
  */
 import AlgoliaAnalytics from "../insights";
-import { getRequesterForNode } from "../utils/getRequesterForNode";
 import { getFunctionalInterface } from "../_getFunctionalInterface";
-import { setUserToken } from "../_tokenUtils";
 import { version } from "../../package.json";
-
-const credentials = {
-  apiKey: "testKey",
-  appId: "testId"
-};
 
 const defaultPayload = {
   eventName: "my-event",
@@ -27,7 +20,11 @@ describe("_sendEvent in node env", () => {
     requestFn = jest.fn((url, data) => {});
     const instance = new AlgoliaAnalytics({ requestFn });
     aa = getFunctionalInterface(instance);
-    aa("init", credentials);
+    aa("init", {
+      apiKey: "testKey",
+      appId: "testId",
+      anonymousUserToken: false
+    });
   });
 
   it("does not throw when user token is not set", () => {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -425,7 +425,7 @@ describe("sendEvents", () => {
       expect(payload).toEqual({
         events: [
           expect.objectContaining({
-            userToken: expect.stringMatching(/^anon-/)
+            userToken: expect.stringMatching(/^anonymous-/)
           })
         ]
       });

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -20,6 +20,10 @@ export function makeSendEvents(requestFn: RequestFnType) {
       );
     }
 
+    if (!this._userToken && this._anonymousUserToken) {
+      this.setAnonymousUserToken(true);
+    }
+
     const events: InsightsEvent[] = eventData.map((data) => {
       const { filters, ...rest } = data;
 

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -26,7 +26,12 @@ export const getCookie = (name: string): string => {
   return "";
 };
 
-export function setAnonymousUserToken(): void {
+export function setAnonymousUserToken(inMemory = false): void {
+  if (inMemory) {
+    this.setUserToken(`anon-${createUUID()}`);
+    return;
+  }
+
   if (!supportsCookies()) {
     return;
   }

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -28,13 +28,14 @@ export const getCookie = (name: string): string => {
 
 export function setAnonymousUserToken(inMemory = false): void {
   if (inMemory) {
-    this.setUserToken(`anon-${createUUID()}`);
+    this.setUserToken(`anonymous-${createUUID()}`);
     return;
   }
 
   if (!supportsCookies()) {
     return;
   }
+
   const foundToken = getCookie(COOKIE_KEY);
   if (
     !foundToken ||

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -13,6 +13,7 @@ export interface InitParams {
   apiKey?: string;
   appId?: string;
   userHasOptedOut?: boolean;
+  anonymousUserToken?: boolean;
   useCookie?: boolean;
   cookieDuration?: number;
   region?: InsightRegion;
@@ -56,6 +57,7 @@ You can visit https://algolia.com/events/debugger instead.`);
     _userHasOptedOut: !!options.userHasOptedOut,
     _region: options.region,
     _host: options.host,
+    _anonymousUserToken: options.anonymousUserToken ?? true,
     _useCookie: options.useCookie ?? false,
     _cookieDuration: options.cookieDuration || 6 * MONTH
   });
@@ -78,7 +80,12 @@ You can visit https://algolia.com/events/debugger instead.`);
 
 type ThisParams = Pick<
   AlgoliaAnalytics,
-  "_userHasOptedOut" | "_useCookie" | "_cookieDuration" | "_region" | "_host"
+  | "_userHasOptedOut"
+  | "_anonymousUserToken"
+  | "_useCookie"
+  | "_cookieDuration"
+  | "_region"
+  | "_host"
 >;
 
 function setOptions(

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -57,6 +57,7 @@ class AlgoliaAnalytics {
   _region: string;
   _host: string;
   _endpointOrigin = "https://insights.algolia.io";
+  _anonymousUserToken = true;
   _userToken: string;
   _userHasOptedOut = false;
   _useCookie = false;


### PR DESCRIPTION
This PR introduces a new initialization parameter: `anonymousUserToken`. This boolean (set to `true` by default) generates an in-memory anonymous user token which is sent with every Insights event.

See [FX-2303](https://algolia.atlassian.net/browse/FX-2303) for more information.

[FX-2303]: https://algolia.atlassian.net/browse/FX-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ