### PR TITLE
feat: add host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ aa('setUserToken', 'USER_ID');
 | `apiKey`          | `string`       | None                     | The search API key of your Algolia application. |
 | `userHasOptedOut` | `boolean`      | `false`                  | Whether to exclude users from analytics.        |
 | `region`          | `'de' \| 'us'` | Automatic                | The DNS server to target.                       |
+| `host`            | `string`       | None                     | The URL to route requests through before they're forwarded to Algolia. |
 | `useCookie`       | `boolean`      | `false`                  | Whether to use cookie in browser environment. The anonymous user token will not be set if `false`. When `useCookie` is `false` and `setUserToken` is not called yet, sending events will throw errors because there is no user token to attach to the events. |
 | `cookieDuration`  | `number`       | `15552000000` (6 months) | The cookie duration in milliseconds.            |
 | `userToken`       | `string`       | `undefined` (optional)   | Initial userToken. When given, anonymous userToken will not be set. |

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -214,6 +214,9 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.de.algolia.io"
+    );
 
     analyticsInstance.init({ apiKey: "apiKey2", appId: "appId2" });
 
@@ -225,6 +228,9 @@ describe("init", () => {
     expect(analyticsInstance._cookieDuration).toBe(15552000000);
     // Custom user token isn't reset on `init` if not provided
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.algolia.io"
+    );
   });
   it("should not merge with previous options when `partial` is `false`", () => {
     analyticsInstance.init({
@@ -244,6 +250,9 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.de.algolia.io"
+    );
 
     analyticsInstance.init({
       apiKey: "apiKey2",
@@ -259,6 +268,9 @@ describe("init", () => {
     expect(analyticsInstance._cookieDuration).toBe(15552000000);
     // The user token isn't reset on `init` when not provided
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.algolia.io"
+    );
   });
   it("should merge with previous options when `partial` is `true`", () => {
     analyticsInstance.init({
@@ -278,6 +290,9 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.de.algolia.io"
+    );
 
     analyticsInstance.init({
       apiKey: "apiKey2",
@@ -292,6 +307,9 @@ describe("init", () => {
     expect(analyticsInstance._useCookie).toBe(true);
     expect(analyticsInstance._cookieDuration).toBe(100);
     expect(analyticsInstance._userToken).toBe("myUserToken");
+    expect(analyticsInstance._endpointOrigin).toBe(
+      "https://insights.de.algolia.io"
+    );
 
     analyticsInstance.init({
       appId: "appId2",

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -37,6 +37,14 @@ describe("init", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX", region: "us" });
     expect(analyticsInstance._region).toBe("us");
   });
+  it("should set _host on instance", () => {
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      host: "https://example.com"
+    });
+    expect(analyticsInstance._host).toBe("https://example.com");
+  });
   it("should set _userHasOptedOut on instance to false by default", () => {
     analyticsInstance.init({ apiKey: "***", appId: "XXX" });
     expect(analyticsInstance._userHasOptedOut).toBe(false);
@@ -318,6 +326,13 @@ describe("init", () => {
 
     expect(analyticsInstance._appId).toBe("appId2");
     expect(analyticsInstance._apiKey).toBe("apiKey2");
+
+    analyticsInstance.init({
+      host: "https://example.com",
+      partial: true
+    });
+
+    expect(analyticsInstance._endpointOrigin).toBe("https://example.com");
   });
 
   describe("callback for userToken", () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -111,6 +111,15 @@ describe("init", () => {
       "https://insights.de.algolia.io"
     );
   });
+  it("should set _endpointOrigin on instance to https://example.com if host is provided, overriding any region passed", () => {
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      region: "de",
+      host: "https://example.com"
+    });
+    expect(analyticsInstance._endpointOrigin).toBe("https://example.com");
+  });
   it("should set anonymous userToken if environment supports cookies", () => {
     const supportsCookies = jest
       .spyOn(utils, "supportsCookies")

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -60,8 +60,8 @@ You can visit https://algolia.com/events/debugger instead.`);
 
   this._endpointOrigin =
     options.host ||
-    (options.region
-      ? `https://insights.${options.region}.algolia.io`
+    (this._region
+      ? `https://insights.${this._region}.algolia.io`
       : "https://insights.algolia.io");
 
   // user agent

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -2,6 +2,7 @@ import { isUndefined, isNumber } from "./utils";
 import { DEFAULT_ALGOLIA_AGENTS } from "./_algoliaAgent";
 import objectAssignPolyfill from "./polyfills/objectAssign";
 import { MONTH } from "./_tokenUtils";
+import AlgoliaAnalytics from "./insights";
 
 objectAssignPolyfill();
 
@@ -24,7 +25,7 @@ export interface InitParams {
  * Binds credentials and settings to class
  * @param options: initParams
  */
-export function init(options: InitParams = {}) {
+export function init(this: AlgoliaAnalytics, options: InitParams = {}) {
   if (
     !isUndefined(options.region) &&
     SUPPORTED_REGIONS.indexOf(options.region) === -1
@@ -54,12 +55,13 @@ You can visit https://algolia.com/events/debugger instead.`);
   setOptions(this, options, {
     _userHasOptedOut: !!options.userHasOptedOut,
     _region: options.region,
+    _host: options.host,
     _useCookie: options.useCookie ?? false,
     _cookieDuration: options.cookieDuration || 6 * MONTH
   });
 
   this._endpointOrigin =
-    options.host ||
+    this._host ||
     (this._region
       ? `https://insights.${this._region}.algolia.io`
       : "https://insights.algolia.io");
@@ -74,15 +76,13 @@ You can visit https://algolia.com/events/debugger instead.`);
   }
 }
 
-type ThisParams = {
-  _userHasOptedOut: InitParams["userHasOptedOut"];
-  _useCookie: InitParams["useCookie"];
-  _cookieDuration: InitParams["cookieDuration"];
-  _region: InitParams["region"];
-};
+type ThisParams = Pick<
+  AlgoliaAnalytics,
+  "_userHasOptedOut" | "_useCookie" | "_cookieDuration" | "_region" | "_host"
+>;
 
 function setOptions(
-  target: ThisParams,
+  target: AlgoliaAnalytics,
   { partial: partial, ...options }: InitParams,
   defaultValues: ThisParams
 ) {

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -17,6 +17,7 @@ export interface InitParams {
   region?: InsightRegion;
   userToken?: string;
   partial?: boolean;
+  host?: string;
 }
 
 /**
@@ -57,9 +58,11 @@ You can visit https://algolia.com/events/debugger instead.`);
     _cookieDuration: options.cookieDuration || 6 * MONTH
   });
 
-  this._endpointOrigin = options.region
-    ? `https://insights.${options.region}.algolia.io`
-    : "https://insights.algolia.io";
+  this._endpointOrigin =
+    options.host ||
+    (options.region
+      ? `https://insights.${options.region}.algolia.io`
+      : "https://insights.algolia.io");
 
   // user agent
   this._ua = [...DEFAULT_ALGOLIA_AGENTS];

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -55,6 +55,7 @@ class AlgoliaAnalytics {
   _apiKey: string;
   _appId: string;
   _region: string;
+  _host: string;
   _endpointOrigin = "https://insights.algolia.io";
   _userToken: string;
   _userHasOptedOut = false;


### PR DESCRIPTION
Backport the `host` option submitted by a customer.
Fix `_endpointOrigin` being overwritten when using init with the `partial` option (region was not being preserved).