### PR TITLE
ci: replace all versions in readme during release

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ To work around this problem and ensure you capture all interactions occurring be
 <!-- prettier-ignore-start -->
 ```html
 <script>
-var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.0.2/dist/search-insights.iife.min.js";
+var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.iife.min.js";
 
 !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
-(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
+(e[s].queue=e[s].queue||[]).push(arguments)},e[s].version=(n.match(/@([^\/]+)\/?/) || [])[1],i=a.createElement(t),c=a.getElementsByTagName(t)[0],
 i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
 }(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
 </script>

--- a/ship.config.js
+++ b/ship.config.js
@@ -4,7 +4,7 @@ const path = require("path");
 module.exports = {
   shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
     const { fix = 0 } = commitNumbersPerType;
-    if (releaseType === 'patch' && fix === 0) {
+    if (releaseType === "patch" && fix === 0) {
       return false;
     }
     return true;
@@ -19,7 +19,8 @@ module.exports = {
     ) {
       const readmePath = path.resolve(dir, "README.md");
       let content = fs.readFileSync(readmePath).toString();
-      const regex = /cdn\.jsdelivr\.net\/npm\/search-insights@(\d+?\.\d+?\.\d+?)/;
+      const regex =
+        /cdn\.jsdelivr\.net\/npm\/search-insights@(\d+?\.\d+?\.\d+?)/g;
       const newUrl = `cdn.jsdelivr.net/npm/search-insights@${version}`;
       content = content.replace(regex, newUrl);
       fs.writeFileSync(readmePath, content);


### PR DESCRIPTION
This PR ensures all script snippets in the README have their versions updated when doing a release.

This also adds the `<aa>.version` property on the second snippet, so that other libraries can rely on it to enable automatic insights if relevant.