### PR TITLE
chore: update readme snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ We recommend loading the library by adding the snippet below to all pages where 
 <!-- prettier-ignore-start -->
 ```html
 <script>
-var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.2.3";
+var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.6.0";
 
 !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
-(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
+(e[s].queue=e[s].queue||[]).push(arguments)},e[s].version=(n.match(/@([^\/]+)\/?/) || [])[1],i=a.createElement(t),c=a.getElementsByTagName(t)[0],
 i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
 }(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
 </script>
@@ -90,10 +90,10 @@ To work around this problem and ensure you capture all interactions occurring be
 <!-- prettier-ignore-start -->
 ```html
 <script>
-var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.0.2/dist/search-insights.iife.min.js";
+var ALGOLIA_INSIGHTS_SRC = "https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.iife.min.js";
 
 !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e[s]=e[s]||function(){
-(e[s].queue=e[s].queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],
+(e[s].queue=e[s].queue||[]).push(arguments)},e[s].version=(n.match(/@([^\/]+)\/?/) || [])[1],i=a.createElement(t),c=a.getElementsByTagName(t)[0],
 i.async=1,i.src=n,c.parentNode.insertBefore(i,c)
 }(window,document,"script",ALGOLIA_INSIGHTS_SRC,"aa");
 </script>


### PR DESCRIPTION
This PR makes sure the default snippets we show on the README reference the version that supports automatic insights and include the `<aa>.version` property that allows libraries to reliably identify them.