### PR TITLE
chore: update package owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "git+https://github.com/algolia/search-insights.js.git"
   },
   "author": {
-    "name": "Jonas Badalic",
+    "name": "Algolia",
     "url": "https://www.algolia.com"
   },
   "license": "MIT",


### PR DESCRIPTION
Not really sure how this happened, but this https://github.com/algolia/search-insights.js/pull/374 seems to been accidentally reverted.
