### PR TITLE
fix: remove engines config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "http": "./empty-module.cjs.js",
     "https": "./empty-module.cjs.js"
   },
-  "engines": {
-    "node": ">=16.0.0"
-  },
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
This config is a warning at best and only enforced if https://docs.npmjs.com/cli/v9/using-npm/config#engine-strict is set.

Our node version requirements are for building and testing the package, rather than actually running the code.

CR-4263