### PR TITLE
fix: add missing type defs for conversion subtypes

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,6 +85,8 @@ export type InsightsEventType = "click" | "conversion" | "view";
 export type InsightsEventConversionSubType = "addToCart" | "purchase";
 
 export type InsightsEventObjectData = {
+  queryID?: string;
+
   price?: number;
   discount?: number;
   quantity?: number;
@@ -105,6 +107,9 @@ export type InsightsEvent = {
   objectData?: InsightsEventObjectData[];
 
   filters?: string[];
+
+  value?: number;
+  currency?: string;
 };
 
 export type InsightsAdditionalEventParams = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -87,8 +87,8 @@ export type InsightsEventConversionSubType = "addToCart" | "purchase";
 export type InsightsEventObjectData = {
   queryID?: string;
 
-  price?: number;
-  discount?: number;
+  price?: number | string;
+  discount?: number | string;
   quantity?: number;
 };
 
@@ -108,7 +108,7 @@ export type InsightsEvent = {
 
   filters?: string[];
 
-  value?: number;
+  value?: number | string;
   currency?: string;
 };
 


### PR DESCRIPTION
The new conversion subtypes added a top level value and currency attribute to the event object, as well as allowing a queryID to be provided via the objectData.

EEX-703
