### PR TITLE
chore(ci): setup git user for shipjs post-release tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,8 @@ jobs:
       - run:
           name: Trigger a release if the latest commit is a release commit
           command: |
+            git config --global user.email "algobot@users.noreply.github.com"
+            git config --global user.name "algobot"
             yarn shipjs trigger
   "prepare release":
     <<: *node_v18


### PR DESCRIPTION
Hey team 👋 , I got notified of a pipeline fail in the release process for this repository. 

This is due to newer versions of Shipjs creating annotated tags, which require git credentials.

This PR sets up a dummy Git user to allow Shipjs to correctly perform post release tasks: git tag creation and github release publication. This should allow next releases to be run more smoothly.