### PR TITLE
fix: expose purchase and addToCard insights client methods

### DIFF
--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -13,6 +13,7 @@ export interface InsightsSearchConversionEvent {
   queryID: string;
   objectIDs: string[];
   objectData?: InsightsEvent["objectData"];
+  currency?: InsightsEvent["currency"];
 }
 
 export function convertedObjectIDsAfterSearch(
@@ -59,6 +60,7 @@ export interface InsightsSearchConversionObjectIDsEvent {
 
   objectIDs: string[];
   objectData?: InsightsEvent["objectData"];
+  currency?: InsightsEvent["currency"];
 }
 
 export function convertedObjectIDs(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,11 @@ import type {
 import type {
   convertedObjectIDsAfterSearch,
   convertedObjectIDs,
-  convertedFilters
+  convertedFilters,
+  purchasedObjectIDs,
+  purchasedObjectIDsAfterSearch,
+  addedToCartObjectIDsAfterSearch,
+  addedToCartObjectIDs
 } from "./conversion";
 import type { init } from "./init";
 import type { viewedObjectIDs, viewedFilters } from "./view";
@@ -36,6 +40,14 @@ export type InsightsMethodMap = {
   convertedFilters: Parameters<typeof convertedFilters>;
   viewedObjectIDs: Parameters<typeof viewedObjectIDs>;
   viewedFilters: Parameters<typeof viewedFilters>;
+  purchasedObjectIDs: Parameters<typeof purchasedObjectIDs>;
+  purchasedObjectIDsAfterSearch: Parameters<
+    typeof purchasedObjectIDsAfterSearch
+  >;
+  addedToCartObjectIDs: Parameters<typeof addedToCartObjectIDs>;
+  addedToCartObjectIDsAfterSearch: Parameters<
+    typeof addedToCartObjectIDsAfterSearch
+  >;
   sendEvents: Parameters<ReturnType<typeof makeSendEvents>>;
 };
 


### PR DESCRIPTION
The `purchasedObjectIDs`, `purchasedObjectIDsAfterSearch`, `addedToCartObjectIDs`, and `addedToCartObjectIDsAfterSearch` methods were added recently, but haven't been made accessible via the Insights client.

Also add the missing `currency` attribute to the conversion event types.

[EEX-737](https://algolia.atlassian.net/browse/EEX-737)