### PR TITLE
feat: add support for authenticatedUserToken

### DIFF
--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -29,7 +29,7 @@ aa("init", {
 
 ## 3. Add `userToken`
 
-On the Node.js environment, unlike the browser environment, a [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken) (`userToken` and/or `authenticatedUserToken`) must be specified when sending any event.
+On the Node.js environment, unlike the browser environment, a [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken) (required `userToken` and optional `authenticatedUserToken`) must be specified when sending any event.
 
 ```js
 // Anonymous user ID
@@ -40,6 +40,7 @@ aa("clickedObjectIDs", {
 
 // Authenticated user ID
 aa("clickedObjectIDs", {
+  userToken: "ANONYMOUS_ID",
   authenticatedUserToken: "USER_ID"
   // ...
 });

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -29,11 +29,18 @@ aa("init", {
 
 ## 3. Add `userToken`
 
-On the Node.js environment, unlike the browser environment, `userToken` must be specified when sending any event.
+On the Node.js environment, unlike the browser environment, a [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken) (`userToken` and/or `authenticatedUserToken`) must be specified when sending any event.
 
 ```js
+// Anonymous user ID
 aa("clickedObjectIDs", {
-  userToken: "USER_ID"
+  userToken: "ANONYMOUS_ID"
+  // ...
+});
+
+// Authenticated user ID
+aa("clickedObjectIDs", {
+  authenticatedUserToken: "USER_ID"
   // ...
 });
 ```

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -403,7 +403,7 @@ describe("sendEvents", () => {
       });
     });
 
-    it("should be added by default", () => {
+    it("should be added by default if authenticatedUserToken not provided", () => {
       expect(analyticsInstance._anonymousUserToken).toBe(true);
 
       analyticsInstance.sendEvents(
@@ -490,6 +490,41 @@ describe("sendEvents", () => {
           expect.objectContaining({
             userToken: "my-user-token"
           })
+        ]
+      });
+    });
+
+    it("should not be added if authenticatedUserToken is provided", () => {
+      analyticsInstance.setAuthenticatedUserToken("my-user-token");
+
+      analyticsInstance.sendEvents(
+        [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"]
+          }
+        ],
+        {
+          headers: {
+            "X-Algolia-Application-Id": "algoliaAppId",
+            "X-Algolia-API-Key": "algoliaApiKey"
+          }
+        }
+      );
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload).toEqual({
+        events: [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"],
+            authenticatedUserToken: "my-user-token",
+            userToken: undefined
+          }
         ]
       });
     });

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -495,6 +495,82 @@ describe("sendEvents", () => {
     });
   });
 
+  describe("authenticatedUserToken", () => {
+    let analyticsInstance: AlgoliaAnalytics;
+    beforeEach(() => {
+      analyticsInstance = setupInstance();
+    });
+
+    it("should add authenticatedUserToken if initially set and not provided", () => {
+      analyticsInstance.setAuthenticatedUserToken("authed-user-id");
+      analyticsInstance.sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload).toEqual({
+        events: [
+          expect.objectContaining({
+            authenticatedUserToken: "authed-user-id"
+          })
+        ]
+      });
+    });
+
+    it("should not add authenticatedUserToken if not initially set and not provided", () => {
+      analyticsInstance.sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload).toEqual({
+        events: [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: "mock-user-id"
+          }
+        ]
+      });
+    });
+
+    it("should pass over provided authenticatedUserToken", () => {
+      analyticsInstance.setAuthenticatedUserToken("authed-user-id");
+      analyticsInstance.sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"],
+          userToken: "007",
+          authenticatedUserToken: "008"
+        }
+      ]);
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload).toEqual({
+        events: [
+          expect.objectContaining({
+            userToken: "007",
+            authenticatedUserToken: "008"
+          })
+        ]
+      });
+    });
+  });
+
   describe("filters", () => {
     let analyticsInstance: AlgoliaAnalytics;
     beforeEach(() => {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -403,7 +403,7 @@ describe("sendEvents", () => {
       });
     });
 
-    it("should be added by default if authenticatedUserToken not provided", () => {
+    it("should be added by default", () => {
       expect(analyticsInstance._anonymousUserToken).toBe(true);
 
       analyticsInstance.sendEvents(
@@ -429,6 +429,41 @@ describe("sendEvents", () => {
           expect.objectContaining({
             userToken: expect.stringMatching(/^anonymous-/)
           })
+        ]
+      });
+    });
+
+    it("should be added by default even if authenticatedUserToken is provided", () => {
+      analyticsInstance.setAuthenticatedUserToken("my-user-token");
+
+      analyticsInstance.sendEvents(
+        [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"]
+          }
+        ],
+        {
+          headers: {
+            "X-Algolia-Application-Id": "algoliaAppId",
+            "X-Algolia-API-Key": "algoliaApiKey"
+          }
+        }
+      );
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload).toEqual({
+        events: [
+          {
+            eventType: "click",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"],
+            authenticatedUserToken: "my-user-token",
+            userToken: expect.stringMatching(/^anonymous-/)
+          }
         ]
       });
     });
@@ -490,41 +525,6 @@ describe("sendEvents", () => {
           expect.objectContaining({
             userToken: "my-user-token"
           })
-        ]
-      });
-    });
-
-    it("should not be added if authenticatedUserToken is provided", () => {
-      analyticsInstance.setAuthenticatedUserToken("my-user-token");
-
-      analyticsInstance.sendEvents(
-        [
-          {
-            eventType: "click",
-            eventName: "my-event",
-            index: "my-index",
-            objectIDs: ["1"]
-          }
-        ],
-        {
-          headers: {
-            "X-Algolia-Application-Id": "algoliaAppId",
-            "X-Algolia-API-Key": "algoliaApiKey"
-          }
-        }
-      );
-      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(1);
-      const payload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
-      expect(payload).toEqual({
-        events: [
-          {
-            eventType: "click",
-            eventName: "my-event",
-            index: "my-index",
-            objectIDs: ["1"],
-            authenticatedUserToken: "my-user-token",
-            userToken: undefined
-          }
         ]
       });
     });

--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -31,6 +31,7 @@ describe("tokenUtils", () => {
     // clear cookies
     document.cookie = "_ALGOLIA=;expires=Thu, 01-Jan-1970 00:00:01 GMT;";
   });
+
   describe("setUserToken", () => {
     describe("anonymous userToken", () => {
       it("should create a cookie with a UUID", () => {
@@ -52,6 +53,7 @@ describe("tokenUtils", () => {
         expect(document.cookie).toBe("_ALGOLIA=anonymous-mock-uuid-2");
       });
     });
+
     describe("provided userToken", () => {
       it("should not create a cookie with provided userToken", () => {
         analyticsInstance.setUserToken("007");
@@ -71,6 +73,20 @@ describe("tokenUtils", () => {
       });
     });
   });
+
+  describe("setAuthenticatedUserToken", () => {
+    it("should set authenticatedUserToken", () => {
+      expect(analyticsInstance._authenticatedUserToken).toBeUndefined();
+
+      analyticsInstance.setAuthenticatedUserToken("008");
+      expect(analyticsInstance._authenticatedUserToken).toBe("008");
+    });
+    it("should not create a cookie with provided authenticatedUserToken", () => {
+      analyticsInstance.setAuthenticatedUserToken("008");
+      expect(document.cookie).toBe("");
+    });
+  });
+
   describe("getUserToken", () => {
     beforeEach(() => {
       analyticsInstance.setUserToken("007");

--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -96,6 +96,7 @@ describe("tokenUtils", () => {
       expect(userToken).toEqual("007");
     });
     it("should accept a callback", () => {
+      expect.assertions(2);
       analyticsInstance.getUserToken({}, (err, userToken) => {
         expect(err).toEqual(null);
         expect(userToken).toEqual("007");
@@ -134,6 +135,7 @@ describe("tokenUtils", () => {
       expect(authenticatedUserToken).toEqual("008");
     });
     it("should accept a callback", () => {
+      expect.assertions(2);
       analyticsInstance.setAuthenticatedUserToken("009");
       analyticsInstance.getAuthenticatedUserToken(
         {},

--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -120,4 +120,28 @@ describe("tokenUtils", () => {
       });
     });
   });
+
+  describe("getAuthenticatedUserToken", () => {
+    it("should return undefined if not set", () => {
+      const authenticatedUserToken =
+        analyticsInstance.getAuthenticatedUserToken();
+      expect(authenticatedUserToken).toBeUndefined();
+    });
+    it("should return current authenticatedUserToken", () => {
+      analyticsInstance.setAuthenticatedUserToken("008");
+      const authenticatedUserToken =
+        analyticsInstance.getAuthenticatedUserToken();
+      expect(authenticatedUserToken).toEqual("008");
+    });
+    it("should accept a callback", () => {
+      analyticsInstance.setAuthenticatedUserToken("009");
+      analyticsInstance.getAuthenticatedUserToken(
+        {},
+        (err, authenticatedUserToken) => {
+          expect(err).toEqual(null);
+          expect(authenticatedUserToken).toEqual("009");
+        }
+      );
+    });
+  });
 });

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -213,6 +213,28 @@ describe("init", () => {
 
     setUserToken.mockRestore();
   });
+  it("should not set anonymous userToken if authenticatedUserToken is set", () => {
+    const setAuthenticatedUserToken = jest.spyOn(
+      analyticsInstance,
+      "setAuthenticatedUserToken"
+    );
+    const setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      useCookie: true,
+      authenticatedUserToken: "abc"
+    });
+    expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(1);
+    expect(setAuthenticatedUserToken).toHaveBeenCalledWith("abc");
+    expect(setUserToken).toHaveBeenCalledTimes(0);
+
+    expect(analyticsInstance._userToken).toBeUndefined();
+    expect(analyticsInstance._authenticatedUserToken).toBe("abc");
+
+    setAuthenticatedUserToken.mockRestore();
+    setUserToken.mockRestore();
+  });
   it("should replace existing options when called again", () => {
     analyticsInstance.init({
       apiKey: "apiKey1",

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -157,6 +157,33 @@ describe("init", () => {
     setAnonymousUserToken.mockRestore();
     supportsCookies.mockRestore();
   });
+  it("should set anonymous userToken even if authenticatedUserToken is set", () => {
+    const setAuthenticatedUserToken = jest.spyOn(
+      analyticsInstance,
+      "setAuthenticatedUserToken"
+    );
+    const setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX",
+      useCookie: true,
+      authenticatedUserToken: "abc"
+    });
+    expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(1);
+    expect(setAuthenticatedUserToken).toHaveBeenCalledWith("abc");
+    expect(setUserToken).toHaveBeenCalledTimes(1);
+    expect(setUserToken).toHaveBeenCalledWith(
+      expect.stringMatching(/^anonymous-/)
+    );
+
+    expect(analyticsInstance._userToken).toEqual(
+      expect.stringMatching(/^anonymous-/)
+    );
+    expect(analyticsInstance._authenticatedUserToken).toBe("abc");
+
+    setAuthenticatedUserToken.mockRestore();
+    setUserToken.mockRestore();
+  });
   it("should not set anonymous userToken if environment does not supports cookies", () => {
     const supportsCookies = jest
       .spyOn(utils, "supportsCookies")
@@ -211,28 +238,6 @@ describe("init", () => {
     });
     expect(setUserToken).toHaveBeenCalledTimes(2);
 
-    setUserToken.mockRestore();
-  });
-  it("should not set anonymous userToken if authenticatedUserToken is set", () => {
-    const setAuthenticatedUserToken = jest.spyOn(
-      analyticsInstance,
-      "setAuthenticatedUserToken"
-    );
-    const setUserToken = jest.spyOn(analyticsInstance, "setUserToken");
-    analyticsInstance.init({
-      apiKey: "***",
-      appId: "XXX",
-      useCookie: true,
-      authenticatedUserToken: "abc"
-    });
-    expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(1);
-    expect(setAuthenticatedUserToken).toHaveBeenCalledWith("abc");
-    expect(setUserToken).toHaveBeenCalledTimes(0);
-
-    expect(analyticsInstance._userToken).toBeUndefined();
-    expect(analyticsInstance._authenticatedUserToken).toBe("abc");
-
-    setAuthenticatedUserToken.mockRestore();
     setUserToken.mockRestore();
   });
   it("should replace existing options when called again", () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -509,6 +509,7 @@ describe("init", () => {
     });
 
     it("can set userToken manually afterwards", (done) => {
+      expect.assertions(3);
       analyticsInstance.init({ apiKey: "***", appId: "XXX", userToken: "abc" });
       analyticsInstance.setUserToken("def");
       expect(setUserToken).toHaveBeenCalledTimes(2);
@@ -537,6 +538,7 @@ describe("init", () => {
     });
 
     it("should set authenticatedUserToken", () => {
+      expect.assertions(3);
       analyticsInstance.init({
         apiKey: "***",
         appId: "XXX",
@@ -550,6 +552,7 @@ describe("init", () => {
     });
 
     it("can set authenticatedUserToken manually afterwards", (done) => {
+      expect.assertions(3);
       analyticsInstance.init({
         apiKey: "***",
         appId: "XXX",
@@ -565,6 +568,7 @@ describe("init", () => {
     });
 
     it("should not set authenticatedUserToken if not passed", () => {
+      expect.assertions(2);
       analyticsInstance.init({
         apiKey: "***",
         appId: "XXX"

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -497,4 +497,60 @@ describe("init", () => {
       });
     });
   });
+
+  describe("authenticatedUserToken param", () => {
+    let setAuthenticatedUserToken: jest.SpyInstance<
+      number | string,
+      [authenticatedUserToken: number | string]
+    >;
+    beforeEach(() => {
+      setAuthenticatedUserToken = jest.spyOn(
+        analyticsInstance,
+        "setAuthenticatedUserToken"
+      );
+    });
+
+    afterEach(() => {
+      setAuthenticatedUserToken.mockRestore();
+    });
+
+    it("should set authenticatedUserToken", () => {
+      analyticsInstance.init({
+        apiKey: "***",
+        appId: "XXX",
+        authenticatedUserToken: "abc"
+      });
+      expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(1);
+      expect(setAuthenticatedUserToken).toHaveBeenCalledWith("abc");
+      analyticsInstance.getAuthenticatedUserToken(null, (_err, value) => {
+        expect(value).toEqual("abc");
+      });
+    });
+
+    it("can set authenticatedUserToken manually afterwards", (done) => {
+      analyticsInstance.init({
+        apiKey: "***",
+        appId: "XXX",
+        authenticatedUserToken: "abc"
+      });
+      analyticsInstance.setAuthenticatedUserToken("def");
+      expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(2);
+      expect(setAuthenticatedUserToken).toHaveBeenLastCalledWith("def");
+      analyticsInstance.getAuthenticatedUserToken(null, (_err, value) => {
+        expect(value).toEqual("def");
+        done();
+      });
+    });
+
+    it("should not set authenticatedUserToken if not passed", () => {
+      analyticsInstance.init({
+        apiKey: "***",
+        appId: "XXX"
+      });
+      expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(0);
+      analyticsInstance.getAuthenticatedUserToken(null, (_err, value) => {
+        expect(value).toBeUndefined();
+      });
+    });
+  });
 });

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -31,7 +31,9 @@ export function makeSendEvents(requestFn: RequestFnType) {
 
       const payload: InsightsEvent = {
         ...rest,
-        userToken: data?.userToken ?? this._userToken
+        userToken: data?.userToken ?? this._userToken,
+        authenticatedUserToken:
+          data?.authenticatedUserToken ?? this._authenticatedUserToken
       };
       if (!isUndefined(filters)) {
         payload.filters = filters.map(encodeURIComponent);

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -22,7 +22,11 @@ export function makeSendEvents(requestFn: RequestFnType) {
       );
     }
 
-    if (!this._userToken && this._anonymousUserToken) {
+    if (
+      !this._userToken &&
+      !this._authenticatedUserToken &&
+      this._anonymousUserToken
+    ) {
       this.setAnonymousUserToken(true);
     }
 

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -22,11 +22,7 @@ export function makeSendEvents(requestFn: RequestFnType) {
       );
     }
 
-    if (
-      !this._userToken &&
-      !this._authenticatedUserToken &&
-      this._anonymousUserToken
-    ) {
+    if (!this._userToken && this._anonymousUserToken) {
       this.setAnonymousUserToken(true);
     }
 

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -68,6 +68,17 @@ export function setUserToken(
   return this._userToken;
 }
 
+export function setAuthenticatedUserToken(
+  this: AlgoliaAnalytics,
+  authenticatedUserToken: number | string
+): number | string {
+  this._authenticatedUserToken = authenticatedUserToken;
+  if (isFunction(this._onAuthenticatedUserTokenChangeCallback)) {
+    this._onAuthenticatedUserTokenChangeCallback(this._authenticatedUserToken);
+  }
+  return this._authenticatedUserToken;
+}
+
 export function getUserToken(
   this: AlgoliaAnalytics,
   options?: any,
@@ -91,5 +102,20 @@ export function onUserTokenChange(
     isFunction(this._onUserTokenChangeCallback)
   ) {
     this._onUserTokenChangeCallback(this._userToken);
+  }
+}
+
+export function onAuthenticatedUserTokenChange(
+  this: AlgoliaAnalytics,
+  callback?: (authenticatedUserToken?: number | string) => void,
+  options?: { immediate: boolean }
+): void {
+  this._onAuthenticatedUserTokenChangeCallback = callback;
+  if (
+    options &&
+    options.immediate &&
+    isFunction(this._onAuthenticatedUserTokenChangeCallback)
+  ) {
+    this._onAuthenticatedUserTokenChangeCallback(this._authenticatedUserToken);
   }
 }

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -68,17 +68,6 @@ export function setUserToken(
   return this._userToken;
 }
 
-export function setAuthenticatedUserToken(
-  this: AlgoliaAnalytics,
-  authenticatedUserToken: number | string
-): number | string {
-  this._authenticatedUserToken = authenticatedUserToken;
-  if (isFunction(this._onAuthenticatedUserTokenChangeCallback)) {
-    this._onAuthenticatedUserTokenChangeCallback(this._authenticatedUserToken);
-  }
-  return this._authenticatedUserToken;
-}
-
 export function getUserToken(
   this: AlgoliaAnalytics,
   options?: any,
@@ -103,6 +92,28 @@ export function onUserTokenChange(
   ) {
     this._onUserTokenChangeCallback(this._userToken);
   }
+}
+
+export function setAuthenticatedUserToken(
+  this: AlgoliaAnalytics,
+  authenticatedUserToken: number | string
+): number | string {
+  this._authenticatedUserToken = authenticatedUserToken;
+  if (isFunction(this._onAuthenticatedUserTokenChangeCallback)) {
+    this._onAuthenticatedUserTokenChangeCallback(this._authenticatedUserToken);
+  }
+  return this._authenticatedUserToken;
+}
+
+export function getAuthenticatedUserToken(
+  this: AlgoliaAnalytics,
+  options?: any,
+  callback?: (err: any, authenticatedUserToken?: number | string) => void
+): number | string | undefined {
+  if (isFunction(callback)) {
+    callback(null, this._authenticatedUserToken);
+  }
+  return this._authenticatedUserToken;
 }
 
 export function onAuthenticatedUserTokenChange(

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -6,6 +6,7 @@ import { extractAdditionalParams } from "./utils";
 export interface InsightsSearchClickEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 
@@ -27,6 +28,7 @@ export function clickedObjectIDsAfterSearch(
 export interface InsightsClickObjectIDsEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 
@@ -46,6 +48,7 @@ export function clickedObjectIDs(
 export interface InsightsClickFiltersEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -7,6 +7,7 @@ import { extractAdditionalParams } from "./utils";
 export interface InsightsSearchConversionEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 
@@ -55,6 +56,7 @@ export function purchasedObjectIDsAfterSearch(
 export interface InsightsSearchConversionObjectIDsEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 
@@ -102,6 +104,7 @@ export function purchasedObjectIDs(
 export interface InsightsSearchConversionFiltersEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -15,6 +15,7 @@ export interface InitParams {
   cookieDuration?: number;
   region?: InsightRegion;
   userToken?: string;
+  authenticatedUserToken?: string;
   partial?: boolean;
   host?: string;
 }
@@ -70,6 +71,10 @@ You can visit https://algolia.com/events/debugger instead.`);
 
   // user agent
   this._ua = [...DEFAULT_ALGOLIA_AGENTS];
+
+  if (options.authenticatedUserToken) {
+    this.setAuthenticatedUserToken(options.authenticatedUserToken);
+  }
 
   if (options.userToken) {
     this.setUserToken(options.userToken);

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -78,7 +78,12 @@ You can visit https://algolia.com/events/debugger instead.`);
 
   if (options.userToken) {
     this.setUserToken(options.userToken);
-  } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
+  } else if (
+    !this._userToken &&
+    !this._userHasOptedOut &&
+    this._useCookie &&
+    !this._authenticatedUserToken
+  ) {
     this.setAnonymousUserToken();
   }
 }

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -78,12 +78,7 @@ You can visit https://algolia.com/events/debugger instead.`);
 
   if (options.userToken) {
     this.setUserToken(options.userToken);
-  } else if (
-    !this._userToken &&
-    !this._userHasOptedOut &&
-    this._useCookie &&
-    !this._authenticatedUserToken
-  ) {
+  } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
   }
 }

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -8,7 +8,9 @@ import {
   setUserToken,
   setAnonymousUserToken,
   onUserTokenChange,
-  MONTH
+  MONTH,
+  setAuthenticatedUserToken,
+  onAuthenticatedUserTokenChange
 } from "./_tokenUtils";
 import {
   clickedObjectIDsAfterSearch,
@@ -55,6 +57,7 @@ class AlgoliaAnalytics {
   _endpointOrigin = "https://insights.algolia.io";
   _anonymousUserToken = true;
   _userToken?: number | string;
+  _authenticatedUserToken?: number | string;
   _userHasOptedOut = false;
   _useCookie = false;
   _cookieDuration = 6 * MONTH;
@@ -63,6 +66,9 @@ class AlgoliaAnalytics {
   _ua: string[] = [];
 
   _onUserTokenChangeCallback?: (userToken?: number | string) => void;
+  _onAuthenticatedUserTokenChangeCallback?: (
+    authenticatedUserToken?: number | string
+  ) => void;
 
   version: string = version;
 
@@ -75,6 +81,8 @@ class AlgoliaAnalytics {
   setAnonymousUserToken: typeof setAnonymousUserToken;
   getUserToken: typeof getUserToken;
   onUserTokenChange: typeof onUserTokenChange;
+  setAuthenticatedUserToken: typeof setAuthenticatedUserToken;
+  onAuthenticatedUserTokenChange: typeof onAuthenticatedUserTokenChange;
 
   sendEvents: ReturnType<typeof makeSendEvents>;
 
@@ -104,6 +112,9 @@ class AlgoliaAnalytics {
     this.setAnonymousUserToken = setAnonymousUserToken.bind(this);
     this.getUserToken = getUserToken.bind(this);
     this.onUserTokenChange = onUserTokenChange.bind(this);
+    this.setAuthenticatedUserToken = setAuthenticatedUserToken.bind(this);
+    this.onAuthenticatedUserTokenChange =
+      onAuthenticatedUserTokenChange.bind(this);
 
     this.clickedObjectIDsAfterSearch = clickedObjectIDsAfterSearch.bind(this);
     this.clickedObjectIDs = clickedObjectIDs.bind(this);

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -10,7 +10,8 @@ import {
   onUserTokenChange,
   MONTH,
   setAuthenticatedUserToken,
-  onAuthenticatedUserTokenChange
+  onAuthenticatedUserTokenChange,
+  getAuthenticatedUserToken
 } from "./_tokenUtils";
 import {
   clickedObjectIDsAfterSearch,
@@ -82,6 +83,7 @@ class AlgoliaAnalytics {
   getUserToken: typeof getUserToken;
   onUserTokenChange: typeof onUserTokenChange;
   setAuthenticatedUserToken: typeof setAuthenticatedUserToken;
+  getAuthenticatedUserToken: typeof getAuthenticatedUserToken;
   onAuthenticatedUserTokenChange: typeof onAuthenticatedUserTokenChange;
 
   sendEvents: ReturnType<typeof makeSendEvents>;
@@ -113,6 +115,7 @@ class AlgoliaAnalytics {
     this.getUserToken = getUserToken.bind(this);
     this.onUserTokenChange = onUserTokenChange.bind(this);
     this.setAuthenticatedUserToken = setAuthenticatedUserToken.bind(this);
+    this.getAuthenticatedUserToken = getAuthenticatedUserToken.bind(this);
     this.onAuthenticatedUserTokenChange =
       onAuthenticatedUserTokenChange.bind(this);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -110,6 +110,7 @@ export type InsightsEvent = {
 
   eventName: string;
   userToken?: number | string;
+  authenticatedUserToken?: number | string;
   timestamp?: number;
   index: string;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,9 @@ import type { makeSendEvents } from "./_sendEvent";
 import type {
   getUserToken,
   setUserToken,
-  onUserTokenChange
+  onUserTokenChange,
+  onAuthenticatedUserTokenChange,
+  setAuthenticatedUserToken
 } from "./_tokenUtils";
 import type {
   clickedObjectIDsAfterSearch,
@@ -30,6 +32,10 @@ export type InsightsMethodMap = {
   setUserToken: Parameters<typeof setUserToken>;
   getUserToken: Parameters<typeof getUserToken>;
   onUserTokenChange: Parameters<typeof onUserTokenChange>;
+  setAuthenticatedUserToken: Parameters<typeof setAuthenticatedUserToken>;
+  onAuthenticatedUserTokenChange: Parameters<
+    typeof onAuthenticatedUserTokenChange
+  >;
   clickedObjectIDsAfterSearch: Parameters<typeof clickedObjectIDsAfterSearch>;
   clickedObjectIDs: Parameters<typeof clickedObjectIDs>;
   clickedFilters: Parameters<typeof clickedFilters>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,8 @@ import type {
   setUserToken,
   onUserTokenChange,
   onAuthenticatedUserTokenChange,
-  setAuthenticatedUserToken
+  setAuthenticatedUserToken,
+  getAuthenticatedUserToken
 } from "./_tokenUtils";
 import type {
   clickedObjectIDsAfterSearch,
@@ -33,6 +34,7 @@ export type InsightsMethodMap = {
   getUserToken: Parameters<typeof getUserToken>;
   onUserTokenChange: Parameters<typeof onUserTokenChange>;
   setAuthenticatedUserToken: Parameters<typeof setAuthenticatedUserToken>;
+  getAuthenticatedUserToken: Parameters<typeof getAuthenticatedUserToken>;
   onAuthenticatedUserTokenChange: Parameters<
     typeof onAuthenticatedUserTokenChange
   >;

--- a/lib/view.ts
+++ b/lib/view.ts
@@ -6,6 +6,7 @@ import { extractAdditionalParams } from "./utils";
 export interface InsightsSearchViewObjectIDsEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 
@@ -25,6 +26,7 @@ export function viewedObjectIDs(
 export interface InsightsSearchViewFiltersEvent {
   eventName: string;
   userToken?: string;
+  authenticatedUserToken?: string;
   timestamp?: number;
   index: string;
 


### PR DESCRIPTION
### What
* Add `authenticatedUserToken` field to event types
* Add `setAuthenticatedUserToken` method to enable users to set the field to be automatically passed in subsequent `sendEvent` calls
* Add `getAuthenticatedUserToken` method to enable users to get the `authenticatedUserToken` field
* Add `onAuthenticatedUserTokenChange` to enable passing a callback on `authenticatedUserToken` change
* Enable `authenticatedUserToken` to be passed on `init`

### Links
[EEX-746](https://algolia.atlassian.net/browse/EEX-746)

More context:
* [Insights user identity proposal (Confluence)](https://algolia.atlassian.net/wiki/spaces/PREDICT/pages/4559470786/Insights+user+identity+proposal)
* [Authenticated user token in Insights pipeline (Confluence)]( https://algolia.atlassian.net/wiki/spaces/EX/pages/4576346340/2023-05-25+Authenticated+user+token+in+Insights+pipeline)

[EEX-746]: https://algolia.atlassian.net/browse/EEX-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ