### PR TITLE
feat: introduce native fetch fallback when http-module is not supported

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,3 @@
 console.info = () => {};
+
+require("jest-fetch-mock").enableMocks();

--- a/lib/utils/__tests__/featureDetection.node.test.ts
+++ b/lib/utils/__tests__/featureDetection.node.test.ts
@@ -6,7 +6,8 @@ import {
   supportsCookies,
   supportsSendBeacon,
   supportsXMLHttpRequest,
-  supportsNodeHttpModule
+  supportsNodeHttpModule,
+  supportsNativeFetch
 } from "../featureDetection";
 
 describe("featureDetection in node env", () => {
@@ -28,6 +29,13 @@ describe("featureDetection in node env", () => {
     it("should return false", () => {
       // it is not available in node env
       expect(supportsXMLHttpRequest()).toBe(false);
+    });
+  });
+
+  describe("supportsNativeFetch", () => {
+    it("should return true", () => {
+      // it is available in node env
+      expect(supportsNativeFetch()).toBe(true);
     });
   });
 

--- a/lib/utils/featureDetection.ts
+++ b/lib/utils/featureDetection.ts
@@ -33,3 +33,11 @@ export const supportsNodeHttpModule = (): boolean => {
     return false;
   }
 };
+
+export const supportsNativeFetch = (): boolean => {
+  try {
+    return fetch !== undefined;
+  } catch (e) {
+    return false;
+  }
+};

--- a/lib/utils/getRequesterForBrowser.ts
+++ b/lib/utils/getRequesterForBrowser.ts
@@ -1,6 +1,14 @@
-import { supportsSendBeacon, supportsXMLHttpRequest } from "./featureDetection";
+import {
+  supportsNativeFetch,
+  supportsSendBeacon,
+  supportsXMLHttpRequest
+} from "./featureDetection";
 import type { RequestFnType } from "./request";
-import { requestWithSendBeacon, requestWithXMLHttpRequest } from "./request";
+import {
+  requestWithNativeFetch,
+  requestWithSendBeacon,
+  requestWithXMLHttpRequest
+} from "./request";
 
 export function getRequesterForBrowser(): RequestFnType {
   if (supportsSendBeacon()) {
@@ -9,6 +17,10 @@ export function getRequesterForBrowser(): RequestFnType {
 
   if (supportsXMLHttpRequest()) {
     return requestWithXMLHttpRequest;
+  }
+
+  if (supportsNativeFetch()) {
+    return requestWithNativeFetch;
   }
 
   throw new Error(

--- a/lib/utils/getRequesterForNode.ts
+++ b/lib/utils/getRequesterForNode.ts
@@ -1,10 +1,17 @@
-import { supportsNodeHttpModule } from "./featureDetection";
+import {
+  supportsNodeHttpModule,
+  supportsNativeFetch
+} from "./featureDetection";
 import type { RequestFnType } from "./request";
-import { requestWithNodeHttpModule } from "./request";
+import { requestWithNodeHttpModule, requestWithNativeFetch } from "./request";
 
 export function getRequesterForNode(): RequestFnType {
   if (supportsNodeHttpModule()) {
     return requestWithNodeHttpModule;
+  }
+
+  if (supportsNativeFetch()) {
+    return requestWithNativeFetch;
   }
 
   throw new Error(

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -78,3 +78,21 @@ export const requestWithNodeHttpModule: RequestFnType = (url, data) => {
     req.end();
   });
 };
+
+export const requestWithNativeFetch: RequestFnType = (url, data) => {
+  return new Promise((resolve, reject) => {
+    fetch(url, {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+      .then((response) => {
+        resolve(response.status === 200);
+      })
+      .catch((e) => {
+        reject(e);
+      });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
+    "jest-fetch-mock": "^3.0.3",
     "jest-localstorage-mock": "^2.4.26",
     "jest-watch-typeahead": "^2.2.2",
     "markdown-toc": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,13 @@ cosmiconfig@5.2.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4331,6 +4338,14 @@ jest-environment-node@^29.6.4:
     jest-mock "^29.6.3"
     jest-util "^29.6.3"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
@@ -5270,7 +5285,7 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5904,6 +5919,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 promise-retry@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
First of all, thank you for maintaining the great library!

As described in issue #444, importing `search-insights` on an '[edge-runtime](https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes)' results in the following error: 
`[Error: Could not find a supported HTTP request client in this environment.]`

The edge runtime however, does [support `fetch`](https://nextjs.org/docs/pages/api-reference/edge) (and is added to node [per version 18](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)).

This PR adds a fallback to the native `fetch` method when nodeHttpRequest is not available.

Please let me know if you'd like to see anything changed :-).

Kind regards.