### PR TITLE
feat: enable unsetting authenticatedUserToken

### DIFF
--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -85,6 +85,13 @@ describe("tokenUtils", () => {
       analyticsInstance.setAuthenticatedUserToken("008");
       expect(document.cookie).toBe("");
     });
+    it("should be able to unset authenticatedUserToken", () => {
+      analyticsInstance.setAuthenticatedUserToken("008");
+      expect(analyticsInstance._authenticatedUserToken).toBe("008");
+
+      analyticsInstance.setAuthenticatedUserToken(undefined);
+      expect(analyticsInstance._authenticatedUserToken).toBeUndefined();
+    });
   });
 
   describe("getUserToken", () => {

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -528,8 +528,8 @@ describe("init", () => {
 
   describe("authenticatedUserToken param", () => {
     let setAuthenticatedUserToken: jest.SpyInstance<
-      number | string,
-      [authenticatedUserToken: number | string]
+      number | string | undefined,
+      [authenticatedUserToken?: number | string]
     >;
     beforeEach(() => {
       setAuthenticatedUserToken = jest.spyOn(
@@ -568,6 +568,22 @@ describe("init", () => {
       expect(setAuthenticatedUserToken).toHaveBeenLastCalledWith("def");
       analyticsInstance.getAuthenticatedUserToken(null, (_err, value) => {
         expect(value).toEqual("def");
+        done();
+      });
+    });
+
+    it("can unset authenticatedUserToken afterwards", (done) => {
+      expect.assertions(3);
+      analyticsInstance.init({
+        apiKey: "***",
+        appId: "XXX",
+        authenticatedUserToken: "abc"
+      });
+      analyticsInstance.setAuthenticatedUserToken(undefined);
+      expect(setAuthenticatedUserToken).toHaveBeenCalledTimes(2);
+      expect(setAuthenticatedUserToken).toHaveBeenLastCalledWith(undefined);
+      analyticsInstance.getAuthenticatedUserToken(null, (_err, value) => {
+        expect(value).toBeUndefined();
         done();
       });
     });

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -96,8 +96,8 @@ export function onUserTokenChange(
 
 export function setAuthenticatedUserToken(
   this: AlgoliaAnalytics,
-  authenticatedUserToken: number | string
-): number | string {
+  authenticatedUserToken: number | string | undefined
+): number | string | undefined {
   this._authenticatedUserToken = authenticatedUserToken;
   if (isFunction(this._onAuthenticatedUserTokenChangeCallback)) {
     this._onAuthenticatedUserTokenChangeCallback(this._authenticatedUserToken);


### PR DESCRIPTION
Users may want to unset the authenticated user token, for example, when a user logs out.

[EEX-836](https://algolia.atlassian.net/browse/EEX-836)

[EEX-836]: https://algolia.atlassian.net/browse/EEX-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ