### PR TITLE
chore: deprecate purchase event top-level queryID param

### DIFF
--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -61,9 +61,9 @@ describe("addedToCartObjectIDsAfterSearch", () => {
     index: "index1",
     eventName: "Product added to cart",
     objectIDs: ["12345"],
-    queryID: "test",
     objectData: [
       {
+        queryID: "test",
         price: "39.98",
         quantity: 2
       }

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -61,9 +61,9 @@ describe("addedToCartObjectIDsAfterSearch", () => {
     index: "index1",
     eventName: "Product added to cart",
     objectIDs: ["12345"],
+    queryID: "test",
     objectData: [
       {
-        queryID: "test",
         price: "39.98",
         quantity: 2
       }
@@ -101,11 +101,11 @@ describe("addedToCartObjectIDsAfterSearch", () => {
 describe("purchasedObjectIDsAfterSearch", () => {
   const convertParams = {
     index: "index1",
-    eventName: "Product added to cart",
+    eventName: "Product purchased",
     objectIDs: ["12345"],
-    queryID: "test",
     objectData: [
       {
+        queryID: "query-1",
         price: 12.99,
         quantity: 2
       }

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -27,25 +27,12 @@ export function convertedObjectIDsAfterSearch(
   return this.sendEvents(addEventType("conversion", events), additionalParams);
 }
 
-export interface InsightsSearchConversionSubtypeEvent {
-  eventName: string;
-  userToken?: string;
-  authenticatedUserToken?: string;
-  timestamp?: number;
-  index: string;
-
-  queryID?: string;
-  objectIDs: string[];
-  objectData?: InsightsEvent["objectData"];
-  currency?: InsightsEvent["currency"];
-}
-
 export function addedToCartObjectIDsAfterSearch(
   this: AlgoliaAnalytics,
-  ...params: Array<WithAdditionalParams<InsightsSearchConversionSubtypeEvent>>
+  ...params: Array<WithAdditionalParams<InsightsSearchConversionEvent>>
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
-    extractAdditionalParams<InsightsSearchConversionSubtypeEvent>(params);
+    extractAdditionalParams<InsightsSearchConversionEvent>(params);
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "addToCart", events),
@@ -53,12 +40,17 @@ export function addedToCartObjectIDsAfterSearch(
   );
 }
 
+export type InsightsSearchPurchaseEvent = Omit<
+  InsightsSearchConversionEvent,
+  "queryID"
+>;
+
 export function purchasedObjectIDsAfterSearch(
   this: AlgoliaAnalytics,
-  ...params: Array<WithAdditionalParams<InsightsSearchConversionSubtypeEvent>>
+  ...params: Array<WithAdditionalParams<InsightsSearchPurchaseEvent>>
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
-    extractAdditionalParams<InsightsSearchConversionSubtypeEvent>(params);
+    extractAdditionalParams<InsightsSearchPurchaseEvent>(params);
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "purchase", events),

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -27,12 +27,25 @@ export function convertedObjectIDsAfterSearch(
   return this.sendEvents(addEventType("conversion", events), additionalParams);
 }
 
+export interface InsightsSearchConversionSubtypeEvent {
+  eventName: string;
+  userToken?: string;
+  authenticatedUserToken?: string;
+  timestamp?: number;
+  index: string;
+
+  queryID?: string;
+  objectIDs: string[];
+  objectData?: InsightsEvent["objectData"];
+  currency?: InsightsEvent["currency"];
+}
+
 export function addedToCartObjectIDsAfterSearch(
   this: AlgoliaAnalytics,
-  ...params: Array<WithAdditionalParams<InsightsSearchConversionEvent>>
+  ...params: Array<WithAdditionalParams<InsightsSearchConversionSubtypeEvent>>
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
-    extractAdditionalParams<InsightsSearchConversionEvent>(params);
+    extractAdditionalParams<InsightsSearchConversionSubtypeEvent>(params);
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "addToCart", events),
@@ -42,10 +55,10 @@ export function addedToCartObjectIDsAfterSearch(
 
 export function purchasedObjectIDsAfterSearch(
   this: AlgoliaAnalytics,
-  ...params: Array<WithAdditionalParams<InsightsSearchConversionEvent>>
+  ...params: Array<WithAdditionalParams<InsightsSearchConversionSubtypeEvent>>
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
-    extractAdditionalParams<InsightsSearchConversionEvent>(params);
+    extractAdditionalParams<InsightsSearchConversionSubtypeEvent>(params);
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "purchase", events),

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -43,7 +43,10 @@ export function addedToCartObjectIDsAfterSearch(
 export type InsightsSearchPurchaseEvent = Omit<
   InsightsSearchConversionEvent,
   "queryID"
->;
+> & {
+  /** @deprecated Use objectData.queryID instead. */
+  queryID?: string;
+};
 
 export function purchasedObjectIDsAfterSearch(
   this: AlgoliaAnalytics,


### PR DESCRIPTION
Create distinct type for `purchase` event parameters - same as a normal `conversion` event but the top-level `queryID` is optional and deprecated.

[EEX-808](https://algolia.atlassian.net/browse/EEX-808)

[EEX-808]: https://algolia.atlassian.net/browse/EEX-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ