### PR TITLE
feat: add value property to conversion events

### DIFF
--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -110,7 +110,8 @@ describe("purchasedObjectIDsAfterSearch", () => {
         quantity: 2
       }
     ],
-    currency: "USD"
+    currency: "USD",
+    value: 25.98
   };
 
   it("should call sendEvents with proper params", () => {
@@ -181,7 +182,8 @@ describe("addedToCartObjectIDs", () => {
         quantity: 17
       }
     ],
-    currency: "GBP"
+    currency: "GBP",
+    value: 21.08
   };
 
   it("should call sendEvents with proper params", () => {

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -14,6 +14,7 @@ export interface InsightsSearchConversionEvent {
   queryID: string;
   objectIDs: string[];
   objectData?: InsightsEvent["objectData"];
+  value?: InsightsEvent["value"];
   currency?: InsightsEvent["currency"];
 }
 


### PR DESCRIPTION
Add ecommerce `value` property to conversion events as specified in the [Insights Update spec](https://algolia.atlassian.net/wiki/spaces/EX/pages/4652531940/Insights+update#Purchase)

[EEX-886](https://algolia.atlassian.net/browse/EEX-886)

[EEX-886]: https://algolia.atlassian.net/browse/EEX-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ