### PR TITLE
feat: add value property to non-search-related conversion events

### DIFF
--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -68,7 +68,8 @@ describe("addedToCartObjectIDsAfterSearch", () => {
         quantity: 2
       }
     ],
-    currency: "JPY"
+    currency: "JPY",
+    value: 79.96
   };
 
   it("should call sendEvents with proper params", () => {
@@ -221,7 +222,8 @@ describe("purchasedObjectIDs", () => {
         quantity: 1
       }
     ],
-    currency: "AUD"
+    currency: "AUD",
+    value: 100
   };
 
   it("should call sendEvents with proper params", () => {

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -71,6 +71,7 @@ export interface InsightsSearchConversionObjectIDsEvent {
 
   objectIDs: string[];
   objectData?: InsightsEvent["objectData"];
+  value?: InsightsEvent["value"];
   currency?: InsightsEvent["currency"];
 }
 


### PR DESCRIPTION
The [previous change](https://github.com/algolia/search-insights.js/pull/526) only applied to 'after search' events