### PR TITLE
feat: fast fail when sending no events

### DIFF
--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -737,6 +737,14 @@ describe("sendEvents", () => {
         }
       );
     });
+
+    it("should fail fast when sending no events via sendEvents", async () => {
+      const result = analyticsInstance.sendEvents([]);
+
+      expect(result).toBeInstanceOf(Promise);
+      expect(await result).toBe(false);
+      expect(fakeRequestFn).toHaveBeenCalledTimes(0);
+    });
   });
 
   it("applies default credentials when no custom ones are provided", () => {

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -41,6 +41,10 @@ export function makeSendEvents(requestFn: RequestFnType) {
       return payload;
     });
 
+    if (events.length === 0) {
+      return Promise.resolve(false);
+    }
+
     return sendRequest(
       requestFn,
       this._ua,


### PR DESCRIPTION
When the events payload is empty don't bother sending the request, fail fast.