### PR TITLE
feat: add query id inference for conversion events based on prior clicks

### DIFF
--- a/lib/__tests__/_addQueryId.test.ts
+++ b/lib/__tests__/_addQueryId.test.ts
@@ -1,0 +1,168 @@
+import { addQueryId } from "../_addQueryId";
+import type { InsightsEvent } from "../types";
+import { storeQueryForObject } from "../utils";
+
+describe("addQueryId", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns the same event if the eventType is not conversion", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "click",
+        index: "index1",
+        eventName: "hit clicked",
+        objectIDs: ["2"]
+      },
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"]
+      }
+    ];
+    expect(addQueryId(events)).toEqual([
+      {
+        eventType: "click",
+        index: "index1",
+        eventName: "hit clicked",
+        objectIDs: ["2"]
+      },
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"],
+        objectData: [{ queryID: "clicked-query" }],
+        objectIDsWithInferredQueryID: ["2"]
+      }
+    ]);
+  });
+
+  it("returns the same event if a top-level queryID is already present", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"],
+        queryID: "test-query"
+      }
+    ];
+    expect(addQueryId(events)).toEqual(events);
+  });
+
+  it("returns the same event if a queryID is already present in objectData", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"],
+        objectData: [{ queryID: "test-query" }]
+      }
+    ];
+    expect(addQueryId(events)).toEqual(events);
+  });
+
+  it("returns the same event if no top-level queryID is present and there's no cache hit", () => {
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"]
+      }
+    ];
+    expect(addQueryId(events)).toEqual(events);
+  });
+
+  it("returns the same event if no queryID is present in the objectData and there's no cache hit", () => {
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"],
+        objectData: [{}]
+      }
+    ];
+    expect(addQueryId(events)).toEqual(events);
+  });
+
+  it("adds the queryID to the event if it's not already present", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"]
+      }
+    ];
+    expect(addQueryId(events)).toEqual([
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2"],
+        objectData: [{ queryID: "clicked-query" }],
+        objectIDsWithInferredQueryID: ["2"]
+      }
+    ]);
+  });
+
+  it("adds the queryID to the event if it's not already present for multiple objects", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    storeQueryForObject("index1", "3", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2", "3"]
+      }
+    ];
+    expect(addQueryId(events)).toEqual([
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2", "3"],
+        objectData: [
+          { queryID: "clicked-query" },
+          { queryID: "clicked-query" }
+        ],
+        objectIDsWithInferredQueryID: ["2", "3"]
+      }
+    ]);
+  });
+
+  it("adds the queryID to the event if it's not already present for one of multiple objects", () => {
+    storeQueryForObject("index1", "2", "clicked-query");
+    storeQueryForObject("index1", "3", "clicked-query");
+    const events: InsightsEvent[] = [
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2", "3"],
+        objectData: [{ queryID: "test-query" }, {}]
+      }
+    ];
+    expect(addQueryId(events)).toEqual([
+      {
+        eventType: "conversion",
+        index: "index1",
+        eventName: "hit converted",
+        objectIDs: ["2", "3"],
+        objectData: [{ queryID: "test-query" }, { queryID: "clicked-query" }],
+        objectIDsWithInferredQueryID: ["3"]
+      }
+    ]);
+  });
+});

--- a/lib/__tests__/click.test.ts
+++ b/lib/__tests__/click.test.ts
@@ -1,4 +1,5 @@
 import AlgoliaAnalytics from "../insights";
+import { getQueryForObject } from "../utils";
 
 const credentials = {
   apiKey: "test",
@@ -20,6 +21,7 @@ beforeEach(() => {
   });
   analyticsInstance.init(credentials);
   analyticsInstance.sendEvents = jest.fn();
+  localStorage.clear();
 });
 
 describe("clickedObjectIDsAfterSearch", () => {
@@ -53,6 +55,15 @@ describe("clickedObjectIDsAfterSearch", () => {
       expect.any(Array),
       additionalParameters
     );
+  });
+
+  it("should store the queryID", () => {
+    expect(getQueryForObject("index1", "2")).toBeUndefined();
+    analyticsInstance.clickedObjectIDsAfterSearch(clickParams);
+    expect(getQueryForObject("index1", "2")).toEqual([
+      "testing",
+      expect.any(Number)
+    ]);
   });
 });
 

--- a/lib/_addQueryId.ts
+++ b/lib/_addQueryId.ts
@@ -1,0 +1,38 @@
+import type { InsightsEvent } from "./types";
+import { getQueryForObject } from "./utils";
+
+export function addQueryId(events: InsightsEvent[]): InsightsEvent[] {
+  return events.map((event) => {
+    if (!isValidEventForQueryIdLookup(event)) {
+      return event;
+    }
+    const objectIDsWithInferredQueryID: string[] = [];
+    const updatedObjectData = event.objectIDs?.map((objectID, i) => {
+      const objectData = event.objectData?.[i];
+      if (objectData?.queryID) {
+        return objectData;
+      }
+
+      const [queryID] = getQueryForObject(event.index, objectID) ?? [];
+      if (queryID) {
+        objectIDsWithInferredQueryID.push(objectID);
+      }
+      return {
+        ...objectData,
+        queryID
+      };
+    });
+    if (objectIDsWithInferredQueryID.length === 0) {
+      return event;
+    }
+    return {
+      ...event,
+      objectData: updatedObjectData,
+      objectIDsWithInferredQueryID
+    };
+  });
+}
+
+function isValidEventForQueryIdLookup(event: InsightsEvent): boolean {
+  return !event.queryID && event.eventType === "conversion";
+}

--- a/lib/_sendEvent.ts
+++ b/lib/_sendEvent.ts
@@ -1,3 +1,4 @@
+import { addQueryId } from "./_addQueryId";
 import type AlgoliaAnalytics from "./insights";
 import type { InsightsAdditionalEventParams, InsightsEvent } from "./types";
 import { isUndefined } from "./utils";
@@ -26,7 +27,9 @@ export function makeSendEvents(requestFn: RequestFnType) {
       this.setAnonymousUserToken(true);
     }
 
-    const events: InsightsEvent[] = eventData.map((data) => {
+    const events: InsightsEvent[] = (
+      additionalParams?.inferQueryID ? addQueryId(eventData) : eventData
+    ).map((data) => {
       const { filters, ...rest } = data;
 
       const payload: InsightsEvent = {

--- a/lib/click.ts
+++ b/lib/click.ts
@@ -1,7 +1,7 @@
 import { addEventType } from "./_addEventType";
 import type AlgoliaAnalytics from "./insights";
 import type { WithAdditionalParams } from "./utils";
-import { extractAdditionalParams } from "./utils";
+import { extractAdditionalParams, storeQueryForObject } from "./utils";
 
 export interface InsightsSearchClickEvent {
   eventName: string;
@@ -21,6 +21,12 @@ export function clickedObjectIDsAfterSearch(
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
     extractAdditionalParams<InsightsSearchClickEvent>(params);
+
+  events.forEach(({ index, queryID, objectIDs }) =>
+    objectIDs.forEach((objectID) =>
+      storeQueryForObject(index, objectID, queryID)
+    )
+  );
 
   return this.sendEvents(addEventType("click", events), additionalParams);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,6 +126,7 @@ export type InsightsEvent = {
   objectIDs?: string[];
   positions?: number[];
   objectData?: InsightsEventObjectData[];
+  objectIDsWithInferredQueryID?: string[];
 
   filters?: string[];
 
@@ -135,4 +136,5 @@ export type InsightsEvent = {
 
 export type InsightsAdditionalEventParams = {
   headers?: Record<string, string>;
+  inferQueryID?: boolean;
 };

--- a/lib/utils/__tests__/localStorage.test.ts
+++ b/lib/utils/__tests__/localStorage.test.ts
@@ -1,0 +1,108 @@
+import { LocalStorage } from "../localStorage";
+
+const setItemMock = jest.spyOn(Object.getPrototypeOf(localStorage), "setItem");
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation(() => {});
+if (!global.navigator.storage) {
+  (global.navigator as any).storage = {
+    estimate: jest.fn()
+  };
+}
+const storageEstimateMock = jest.spyOn(
+  global.navigator.storage,
+  "estimate" as any
+);
+storageEstimateMock.mockResolvedValue({
+  usage: 0,
+  quota: 100
+});
+
+describe("LocalStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("gets a value from localStorage", () => {
+    const key = "testKey";
+    const value = "testValue";
+    localStorage.setItem(key, JSON.stringify(value));
+
+    const result = LocalStorage.get(key);
+
+    expect(result).toEqual(value);
+  });
+
+  it("returns null if the key is not found", () => {
+    const key = "nonExistentKey";
+
+    const result = LocalStorage.get(key);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null if the value cannot be parsed as JSON", () => {
+    const key = "testKey";
+    const value = "invalidJSON";
+    localStorage.setItem(key, value);
+
+    const result = LocalStorage.get(key);
+
+    expect(result).toBeNull();
+  });
+
+  it("sets a value in localStorage", () => {
+    const key = "testKey";
+    const value = "testValue";
+
+    LocalStorage.set(key, value);
+
+    const result = localStorage.getItem(key);
+    expect(result).toEqual(JSON.stringify(value));
+  });
+
+  it("catches the error and logs an error if the storage is full", () => {
+    const key = "testKey";
+    const value = "testValue";
+
+    // Emulate filling up the storage
+    setItemMock.mockImplementationOnce(() => {
+      throw new Error("pretend QuotaExceededError");
+    });
+
+    LocalStorage.set(key, value);
+
+    const result = localStorage.getItem(key);
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes a value from localStorage", () => {
+    const key = "testKey";
+    const value = "testValue";
+    localStorage.setItem(key, JSON.stringify(value));
+
+    LocalStorage.remove(key);
+
+    const result = localStorage.getItem(key);
+    expect(result).toBeNull();
+  });
+
+  it("checks if the storage is nearly full", async () => {
+    expect(await LocalStorage.isNearlyFull()).toBe(false);
+
+    storageEstimateMock.mockResolvedValueOnce({
+      usage: 90,
+      quota: 100
+    });
+
+    expect(await LocalStorage.isNearlyFull()).toBe(false);
+
+    storageEstimateMock.mockResolvedValueOnce({
+      usage: 91,
+      quota: 100
+    });
+
+    expect(await LocalStorage.isNearlyFull()).toBe(true);
+  });
+});

--- a/lib/utils/__tests__/objectQueryTracker.test.ts
+++ b/lib/utils/__tests__/objectQueryTracker.test.ts
@@ -1,0 +1,70 @@
+import { storeQueryForObject, getQueryForObject } from "../objectQueryTracker";
+
+describe("objectQueryTracker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("storeQueryForObject", () => {
+    it("stores a query for an object", () => {
+      const index = "myIndex";
+      const objectID = "123";
+      const queryID = "abc";
+
+      storeQueryForObject(index, objectID, queryID);
+
+      const storedQuery = JSON.parse(
+        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
+      );
+
+      expect(storedQuery).toEqual({
+        [objectID]: [queryID, expect.any(Number)]
+      });
+    });
+
+    it("stores multiple queries for objects", () => {
+      const index = "myIndex";
+      const objectID1 = "123";
+      const objectID2 = "456";
+      const queryID1 = "abc";
+      const queryID2 = "def";
+
+      storeQueryForObject(index, objectID1, queryID1);
+      storeQueryForObject(index, objectID2, queryID2);
+
+      const storedQuery = JSON.parse(
+        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
+      );
+
+      expect(storedQuery).toEqual({
+        [objectID1]: [queryID1, expect.any(Number)],
+        [objectID2]: [queryID2, expect.any(Number)]
+      });
+    });
+  });
+
+  describe("getQueryForObject", () => {
+    it("returns undefined for a non-existent object query", () => {
+      const index = "myIndex";
+      const objectID = "123";
+
+      const storedQuery = getQueryForObject(index, objectID);
+
+      expect(storedQuery).toBeUndefined();
+    });
+
+    it("returns the latest query for an object", () => {
+      const index = "myIndex";
+      const objectID = "123";
+      const queryID1 = "abc";
+      const queryID2 = "def";
+
+      storeQueryForObject(index, objectID, queryID1);
+      storeQueryForObject(index, objectID, queryID2);
+
+      const storedQuery = getQueryForObject(index, objectID);
+
+      expect(storedQuery).toEqual([queryID2, expect.any(Number)]);
+    });
+  });
+});

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -13,3 +13,4 @@ export const isFunction = (value: any): value is Function =>
 
 export * from "./extractAdditionalParams";
 export * from "./featureDetection";
+export * from "./objectQueryTracker";

--- a/lib/utils/localStorage.ts
+++ b/lib/utils/localStorage.ts
@@ -1,0 +1,66 @@
+/**
+ * A utility class for safely interacting with localStorage.
+ */
+export class LocalStorage {
+  static readonly THRESHOLD = 0.9;
+
+  /**
+   * Safely get a value from localStorage.
+   * If the value is not able to be parsed as JSON, this method will return null.
+   *
+   * @param key - String value of the key.
+   * @returns Null if the key is not found or unable to be parsed, the value otherwise.
+   */
+  static get<T>(key: string): T | null {
+    const val = localStorage.getItem(key);
+    if (!val) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(val) as T;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Safely set a value in localStorage.
+   * If the storage is full, this method will catch the error and log a warning.
+   *
+   * @param key - String value of the key.
+   * @param value - Any value to store.
+   */
+  static set(key: string, value: any): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Unable to set ${key} in localStorage, storage may be full.`
+      );
+    }
+  }
+
+  /**
+   * Remove a value from localStorage.
+   *
+   * @param key - String value of the key.
+   */
+  static remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+
+  /**
+   * Check if the storage is nearly full.
+   *
+   * @returns A promise that resolves to a boolean indicating if the storage is > 90% full.
+   */
+  static isNearlyFull(): Promise<boolean> {
+    return navigator.storage.estimate().then(
+      ({ usage, quota }) =>
+        Boolean(usage && quota && usage / quota > LocalStorage.THRESHOLD),
+      () => false
+    );
+  }
+}

--- a/lib/utils/objectQueryTracker.ts
+++ b/lib/utils/objectQueryTracker.ts
@@ -1,0 +1,32 @@
+import { LocalStorage } from "./localStorage";
+
+interface ObjectQueryMap {
+  [objectId: string]: [queryId: string, timestamp: number];
+}
+
+const PREFIX = "AlgoliaObjectQueryCache_";
+
+function getCache(index: string): ObjectQueryMap {
+  return LocalStorage.get(`${PREFIX}${index}`) ?? {};
+}
+function setCache(index: string, objectQueryMap: ObjectQueryMap): void {
+  LocalStorage.set(`${PREFIX}${index}`, objectQueryMap);
+}
+
+export function storeQueryForObject(
+  index: string,
+  objectID: string,
+  queryID: string
+): void {
+  const objectQueryMap = getCache(index);
+
+  objectQueryMap[objectID] = [queryID, Date.now()];
+  setCache(index, objectQueryMap);
+}
+
+export function getQueryForObject(
+  index: string,
+  objectID: string
+): [queryId: string, timestamp: number] | undefined {
+  return getCache(index)[objectID];
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "bundlesize": [
     {
       "path": "./dist/search-insights.min.js",
-      "maxSize": "2.95 kB"
+      "maxSize": "3.30 kB"
     }
   ],
   "packageManager": "yarn@1.22.19"


### PR DESCRIPTION
This is the majority of the inference logic. A couple of things not added yet:
* when `eventSubtype` is `addToCart` store any queryID passed for future `purchase` conversion events
* removal of objectID/queryID association from store when `eventSubtype` is `purchase`
* pruning of associations older than 90 days
