### PR TITLE
feat: query id inference pruning of purchased and oldest associations when limit is reached

### DIFF
--- a/lib/__tests__/_algoliaAgent.test.ts
+++ b/lib/__tests__/_algoliaAgent.test.ts
@@ -1,13 +1,14 @@
 import AlgoliaAnalytics from "../insights";
+import type { RequestFnType } from "../utils/request";
 
 jest.mock("../../package.json", () => ({ version: "1.0.1" }));
 
 describe("algoliaAgent", () => {
   let analyticsInstance: AlgoliaAnalytics;
-  let requestFn: jest.Mock<any, any>;
+  const requestFn: jest.MockedFunction<RequestFnType> = jest.fn();
 
   beforeEach(() => {
-    requestFn = jest.fn();
+    requestFn.mockResolvedValue(true);
     analyticsInstance = new AlgoliaAnalytics({ requestFn });
     analyticsInstance.init({ apiKey: "test", appId: "test" });
   });

--- a/lib/__tests__/_sendEvent.node.test.ts
+++ b/lib/__tests__/_sendEvent.node.test.ts
@@ -5,6 +5,7 @@ import { version } from "../../package.json";
 import { getFunctionalInterface } from "../_getFunctionalInterface";
 import AlgoliaAnalytics from "../insights";
 import type { InsightsClient } from "../types";
+import type { RequestFnType } from "../utils/request";
 
 const defaultPayload = {
   eventName: "my-event",
@@ -16,9 +17,9 @@ const defaultRequestUrl = `https://insights.algolia.io/1/events?X-Algolia-Applic
 
 describe("_sendEvent in node env", () => {
   let aa: InsightsClient;
-  let requestFn: jest.Mock<any, any>;
+  const requestFn: jest.MockedFunction<RequestFnType> = jest.fn();
   beforeEach(() => {
-    requestFn = jest.fn();
+    requestFn.mockResolvedValue(true);
     const instance = new AlgoliaAnalytics({ requestFn });
     aa = getFunctionalInterface(instance);
     aa("init", {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -331,6 +331,21 @@ describe("sendEvents", () => {
       expect(result instanceof Promise).toBe(true);
       expect(result).resolves.toBe("test");
     });
+
+    it("shouldn't error when custom requestFn doesn't return a promise", () => {
+      fakeRequestFn.mockImplementationOnce(() => false);
+
+      const result = analyticsInstance.sendEvents([
+        {
+          eventType: "click",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
+
+      expect(result).toBe(false);
+    });
   });
 
   describe("init", () => {

--- a/lib/__tests__/_sendEvent.test.ts
+++ b/lib/__tests__/_sendEvent.test.ts
@@ -156,6 +156,53 @@ describe("sendEvents", () => {
         ]
       });
     });
+    it("shouldn't infer query ids when additionalParams.inferQueryID is false", () => {
+      storeQueryForObject("my-index", "1", "clicked-query");
+      analyticsInstance.sendEvents(
+        [
+          {
+            eventType: "conversion",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"]
+          }
+        ],
+        { inferQueryID: false }
+      );
+      analyticsInstance.sendEvents([
+        {
+          eventType: "conversion",
+          eventName: "my-event",
+          index: "my-index",
+          objectIDs: ["1"]
+        }
+      ]);
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(2);
+      const payload1 = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(payload1).toEqual({
+        events: [
+          {
+            eventType: "conversion",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: expect.any(String)
+          }
+        ]
+      });
+      const payload2 = JSON.parse(XMLHttpRequest.send.mock.calls[1][0]);
+      expect(payload2).toEqual({
+        events: [
+          {
+            eventType: "conversion",
+            eventName: "my-event",
+            index: "my-index",
+            objectIDs: ["1"],
+            userToken: expect.any(String)
+          }
+        ]
+      });
+    });
   });
 
   describe("with sendBeacon", () => {

--- a/lib/__tests__/conversion.test.ts
+++ b/lib/__tests__/conversion.test.ts
@@ -1,4 +1,5 @@
 import AlgoliaAnalytics from "../insights";
+import { getQueryForObject } from "../utils";
 
 const credentials = {
   apiKey: "test",
@@ -20,6 +21,7 @@ beforeEach(() => {
   });
   analyticsInstance.sendEvents = jest.fn();
   analyticsInstance.init(credentials);
+  localStorage.clear();
 });
 
 describe("convertedObjectIDsAfterSearch", () => {
@@ -96,6 +98,30 @@ describe("addedToCartObjectIDsAfterSearch", () => {
       expect.any(Array),
       additionalParameters
     );
+  });
+
+  it("should store the queryID", () => {
+    expect(getQueryForObject("index1", "12345")).toBeUndefined();
+    analyticsInstance.addedToCartObjectIDsAfterSearch(convertParams);
+    expect(getQueryForObject("index1", "12345")).toEqual([
+      "test",
+      expect.any(Number)
+    ]);
+  });
+
+  it("should store the objectData.queryID if specified", () => {
+    expect(getQueryForObject("index1", "12345")).toBeUndefined();
+    analyticsInstance.addedToCartObjectIDsAfterSearch({
+      ...convertParams,
+      objectData: convertParams.objectData.map((data) => ({
+        ...data,
+        queryID: "objectData-query"
+      }))
+    });
+    expect(getQueryForObject("index1", "12345")).toEqual([
+      "objectData-query",
+      expect.any(Number)
+    ]);
   });
 });
 
@@ -208,6 +234,21 @@ describe("addedToCartObjectIDs", () => {
       expect.any(Array),
       additionalParameters
     );
+  });
+
+  it("should store the objectData.queryID if specified", () => {
+    expect(getQueryForObject("index1", "12345")).toBeUndefined();
+    analyticsInstance.addedToCartObjectIDs({
+      ...convertParams,
+      objectData: convertParams.objectData.map((data) => ({
+        ...data,
+        queryID: "objectData-query"
+      }))
+    });
+    expect(getQueryForObject("index1", "12345")).toEqual([
+      "objectData-query",
+      expect.any(Number)
+    ]);
   });
 });
 

--- a/lib/__tests__/integrationTests.test.ts
+++ b/lib/__tests__/integrationTests.test.ts
@@ -1,0 +1,374 @@
+import AlgoliaAnalytics from "../insights";
+import { getRequesterForBrowser } from "../utils/getRequesterForBrowser";
+
+const credentials = {
+  apiKey: "testKey",
+  appId: "testId"
+};
+
+function setupInstance({
+  requestFn = getRequesterForBrowser(),
+  init = true
+} = {}): AlgoliaAnalytics {
+  const instance = new AlgoliaAnalytics({ requestFn });
+  if (init) instance.init(credentials);
+  instance.setUserToken("mock-user-id");
+  return instance;
+}
+
+describe("integration tests", () => {
+  let XMLHttpRequest: { open: any; send: any };
+
+  beforeEach(() => {
+    localStorage.clear();
+    XMLHttpRequest = {
+      open: jest.spyOn((window as any).XMLHttpRequest.prototype, "open"),
+      send: jest.spyOn((window as any).XMLHttpRequest.prototype, "send")
+    };
+  });
+
+  afterEach(() => {
+    XMLHttpRequest.open.mockClear();
+    XMLHttpRequest.send.mockClear();
+  });
+
+  describe("queryID inference", () => {
+    let analyticsInstance: AlgoliaAnalytics;
+    beforeEach(() => {
+      analyticsInstance = setupInstance();
+    });
+
+    it("does a click, addToCart and purchase with queryID inference", () => {
+      analyticsInstance.clickedObjectIDsAfterSearch({
+        index: "index1",
+        eventName: "hit clicked",
+        positions: [1],
+        objectIDs: ["12345"],
+        queryID: "testing"
+      });
+      analyticsInstance.addedToCartObjectIDs(
+        {
+          index: "index1",
+          eventName: "hit added to cart",
+          objectIDs: ["12345"],
+          objectData: [
+            {
+              price: "1.24",
+              quantity: 17
+            }
+          ],
+          currency: "GBP",
+          value: 21.08
+        },
+        { inferQueryID: true }
+      );
+      analyticsInstance.purchasedObjectIDs(
+        {
+          index: "index1",
+          eventName: "hit purchased",
+          objectIDs: ["12345"],
+          objectData: [
+            {
+              price: "1.24",
+              quantity: 17
+            }
+          ],
+          currency: "GBP",
+          value: 21.08
+        },
+        { inferQueryID: true }
+      );
+
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(3);
+
+      const addToCartPayload = JSON.parse(XMLHttpRequest.send.mock.calls[1][0]);
+      expect(addToCartPayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit added to cart",
+            eventType: "conversion",
+            eventSubtype: "addToCart",
+            objectIDs: ["12345"],
+            objectIDsWithInferredQueryID: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17,
+                queryID: "testing"
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+
+      const purchasePayload = JSON.parse(XMLHttpRequest.send.mock.calls[2][0]);
+      expect(purchasePayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit purchased",
+            eventType: "conversion",
+            eventSubtype: "purchase",
+            objectIDs: ["12345"],
+            objectIDsWithInferredQueryID: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17,
+                queryID: "testing"
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+    });
+
+    it("does a click, addToCart and purchase without queryID inference", () => {
+      analyticsInstance.clickedObjectIDsAfterSearch({
+        index: "index1",
+        eventName: "hit clicked",
+        positions: [1],
+        objectIDs: ["12345"],
+        queryID: "testing"
+      });
+      analyticsInstance.addedToCartObjectIDs({
+        index: "index1",
+        eventName: "hit added to cart",
+        objectIDs: ["12345"],
+        objectData: [
+          {
+            price: "1.24",
+            quantity: 17
+          }
+        ],
+        currency: "GBP",
+        value: 21.08
+      });
+      analyticsInstance.purchasedObjectIDs({
+        index: "index1",
+        eventName: "hit purchased",
+        objectIDs: ["12345"],
+        objectData: [
+          {
+            price: "1.24",
+            quantity: 17
+          }
+        ],
+        currency: "GBP",
+        value: 21.08
+      });
+
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(3);
+
+      const addToCartPayload = JSON.parse(XMLHttpRequest.send.mock.calls[1][0]);
+      expect(addToCartPayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit added to cart",
+            eventType: "conversion",
+            eventSubtype: "addToCart",
+            objectIDs: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+
+      const purchasePayload = JSON.parse(XMLHttpRequest.send.mock.calls[2][0]);
+      expect(purchasePayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit purchased",
+            eventType: "conversion",
+            eventSubtype: "purchase",
+            objectIDs: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+    });
+
+    it("does a addToCart and purchase with queryID inference", () => {
+      analyticsInstance.addedToCartObjectIDs({
+        index: "index1",
+        eventName: "hit added to cart",
+        objectIDs: ["12345"],
+        objectData: [
+          {
+            price: "1.24",
+            quantity: 17,
+            queryID: "testing"
+          }
+        ],
+        currency: "GBP",
+        value: 21.08
+      });
+      analyticsInstance.purchasedObjectIDs(
+        {
+          index: "index1",
+          eventName: "hit purchased",
+          objectIDs: ["12345"],
+          objectData: [
+            {
+              price: "1.24",
+              quantity: 17
+            }
+          ],
+          currency: "GBP",
+          value: 21.08
+        },
+        { inferQueryID: true }
+      );
+
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(2);
+
+      const addToCartPayload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(addToCartPayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit added to cart",
+            eventType: "conversion",
+            eventSubtype: "addToCart",
+            objectIDs: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17,
+                queryID: "testing"
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+
+      const purchasePayload = JSON.parse(XMLHttpRequest.send.mock.calls[1][0]);
+      expect(purchasePayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit purchased",
+            eventType: "conversion",
+            eventSubtype: "purchase",
+            objectIDs: ["12345"],
+            objectIDsWithInferredQueryID: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17,
+                queryID: "testing"
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+    });
+
+    it("does a addToCart and purchase without queryID inference", () => {
+      analyticsInstance.addedToCartObjectIDs({
+        index: "index1",
+        eventName: "hit added to cart",
+        objectIDs: ["12345"],
+        objectData: [
+          {
+            price: "1.24",
+            quantity: 17,
+            queryID: "testing"
+          }
+        ],
+        currency: "GBP",
+        value: 21.08
+      });
+      analyticsInstance.purchasedObjectIDs({
+        index: "index1",
+        eventName: "hit purchased",
+        objectIDs: ["12345"],
+        objectData: [
+          {
+            price: "1.24",
+            quantity: 17
+          }
+        ],
+        currency: "GBP",
+        value: 21.08
+      });
+
+      expect(XMLHttpRequest.send).toHaveBeenCalledTimes(2);
+
+      const addToCartPayload = JSON.parse(XMLHttpRequest.send.mock.calls[0][0]);
+      expect(addToCartPayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit added to cart",
+            eventType: "conversion",
+            eventSubtype: "addToCart",
+            objectIDs: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17,
+                queryID: "testing"
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+
+      const purchasePayload = JSON.parse(XMLHttpRequest.send.mock.calls[1][0]);
+      expect(purchasePayload).toEqual({
+        events: [
+          {
+            index: "index1",
+            eventName: "hit purchased",
+            eventType: "conversion",
+            eventSubtype: "purchase",
+            objectIDs: ["12345"],
+            objectData: [
+              {
+                price: "1.24",
+                quantity: 17
+              }
+            ],
+            currency: "GBP",
+            userToken: "mock-user-id",
+            value: 21.08
+          }
+        ]
+      });
+    });
+  });
+});

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -2,7 +2,7 @@ import { addEventType, addEventTypeAndSubtype } from "./_addEventType";
 import type AlgoliaAnalytics from "./insights";
 import type { InsightsEvent } from "./types";
 import type { WithAdditionalParams } from "./utils";
-import { extractAdditionalParams } from "./utils";
+import { extractAdditionalParams, storeQueryForObject } from "./utils";
 
 export interface InsightsSearchConversionEvent {
   eventName: string;
@@ -34,6 +34,13 @@ export function addedToCartObjectIDsAfterSearch(
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
     extractAdditionalParams<InsightsSearchConversionEvent>(params);
+
+  events.forEach(({ index, queryID, objectIDs, objectData }) =>
+    objectIDs.forEach((objectID, i) => {
+      const objQueryID = objectData?.[i]?.queryID ?? queryID;
+      if (objQueryID) storeQueryForObject(index, objectID, objQueryID);
+    })
+  );
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "addToCart", events),
@@ -91,6 +98,13 @@ export function addedToCartObjectIDs(
 ): ReturnType<AlgoliaAnalytics["sendEvents"]> {
   const { events, additionalParams } =
     extractAdditionalParams<InsightsSearchConversionObjectIDsEvent>(params);
+
+  events.forEach(({ index, objectIDs, objectData }) =>
+    objectIDs.forEach((objectID, i) => {
+      const queryID = objectData?.[i]?.queryID;
+      if (queryID) storeQueryForObject(index, objectID, queryID);
+    })
+  );
 
   return this.sendEvents(
     addEventTypeAndSubtype("conversion", "addToCart", events),

--- a/lib/utils/__tests__/index.test.ts
+++ b/lib/utils/__tests__/index.test.ts
@@ -1,12 +1,19 @@
-import { isFunction, isNumber, isString, isUndefined } from "../index";
+import {
+  isFunction,
+  isNumber,
+  isPromise,
+  isString,
+  isUndefined
+} from "../index";
 
 describe("isUndefined", () => {
   test.each`
-    input         | expected
-    ${42}         | ${false}
-    ${"a string"} | ${false}
-    ${undefined}  | ${true}
-    ${() => null} | ${false}
+    input                | expected
+    ${42}                | ${false}
+    ${"a string"}        | ${false}
+    ${undefined}         | ${true}
+    ${() => null}        | ${false}
+    ${Promise.resolve()} | ${false}
   `("should return $expected when passed $input", ({ input, expected }) => {
     expect(isUndefined(input)).toEqual(expected);
   });
@@ -14,11 +21,12 @@ describe("isUndefined", () => {
 
 describe("isNumber", () => {
   test.each`
-    input         | expected
-    ${42}         | ${true}
-    ${"a string"} | ${false}
-    ${undefined}  | ${false}
-    ${() => null} | ${false}
+    input                | expected
+    ${42}                | ${true}
+    ${"a string"}        | ${false}
+    ${undefined}         | ${false}
+    ${() => null}        | ${false}
+    ${Promise.resolve()} | ${false}
   `("should return $expected when passed $input", ({ input, expected }) => {
     expect(isNumber(input)).toEqual(expected);
   });
@@ -26,11 +34,12 @@ describe("isNumber", () => {
 
 describe("isString", () => {
   test.each`
-    input         | expected
-    ${42}         | ${false}
-    ${"a string"} | ${true}
-    ${undefined}  | ${false}
-    ${() => null} | ${false}
+    input                | expected
+    ${42}                | ${false}
+    ${"a string"}        | ${true}
+    ${undefined}         | ${false}
+    ${() => null}        | ${false}
+    ${Promise.resolve()} | ${false}
   `("should return $expected when passed $input", ({ input, expected }) => {
     expect(isString(input)).toEqual(expected);
   });
@@ -38,12 +47,26 @@ describe("isString", () => {
 
 describe("isFunction", () => {
   test.each`
-    input         | expected
-    ${42}         | ${false}
-    ${"a string"} | ${false}
-    ${undefined}  | ${false}
-    ${() => null} | ${true}
+    input                | expected
+    ${42}                | ${false}
+    ${"a string"}        | ${false}
+    ${undefined}         | ${false}
+    ${() => null}        | ${true}
+    ${Promise.resolve()} | ${false}
   `("should return $expected when passed $input", ({ input, expected }) => {
     expect(isFunction(input)).toEqual(expected);
+  });
+});
+
+describe("isPromise", () => {
+  test.each`
+    input                | expected
+    ${42}                | ${false}
+    ${"a string"}        | ${false}
+    ${undefined}         | ${false}
+    ${() => null}        | ${false}
+    ${Promise.resolve()} | ${true}
+  `("should return $expected when passed $input", ({ input, expected }) => {
+    expect(isPromise(input)).toEqual(expected);
   });
 });

--- a/lib/utils/__tests__/localStorage.test.ts
+++ b/lib/utils/__tests__/localStorage.test.ts
@@ -4,19 +4,6 @@ const setItemMock = jest.spyOn(Object.getPrototypeOf(localStorage), "setItem");
 const consoleErrorSpy = jest
   .spyOn(console, "error")
   .mockImplementation(() => {});
-if (!global.navigator.storage) {
-  (global.navigator as any).storage = {
-    estimate: jest.fn()
-  };
-}
-const storageEstimateMock = jest.spyOn(
-  global.navigator.storage,
-  "estimate" as any
-);
-storageEstimateMock.mockResolvedValue({
-  usage: 0,
-  quota: 100
-});
 
 describe("LocalStorage", () => {
   beforeEach(() => {
@@ -86,23 +73,5 @@ describe("LocalStorage", () => {
 
     const result = localStorage.getItem(key);
     expect(result).toBeNull();
-  });
-
-  it("checks if the storage is nearly full", async () => {
-    expect(await LocalStorage.isNearlyFull()).toBe(false);
-
-    storageEstimateMock.mockResolvedValueOnce({
-      usage: 90,
-      quota: 100
-    });
-
-    expect(await LocalStorage.isNearlyFull()).toBe(false);
-
-    storageEstimateMock.mockResolvedValueOnce({
-      usage: 91,
-      quota: 100
-    });
-
-    expect(await LocalStorage.isNearlyFull()).toBe(true);
   });
 });

--- a/lib/utils/__tests__/objectQueryTracker.test.ts
+++ b/lib/utils/__tests__/objectQueryTracker.test.ts
@@ -1,4 +1,8 @@
-import { storeQueryForObject, getQueryForObject } from "../objectQueryTracker";
+import {
+  storeQueryForObject,
+  getQueryForObject,
+  removeQueryForObjects
+} from "../objectQueryTracker";
 
 describe("objectQueryTracker", () => {
   beforeEach(() => {
@@ -65,6 +69,36 @@ describe("objectQueryTracker", () => {
       const storedQuery = getQueryForObject(index, objectID);
 
       expect(storedQuery).toEqual([queryID2, expect.any(Number)]);
+    });
+  });
+
+  describe("removeQueryForObject", () => {
+    it("removes a query for an object", () => {
+      const index = "myIndex";
+      const objectID1 = "123";
+      const objectID2 = "456";
+      const queryID1 = "abc";
+      const queryID2 = "def";
+
+      storeQueryForObject(index, objectID1, queryID1);
+      storeQueryForObject(index, objectID2, queryID2);
+
+      const storedQuery = JSON.parse(
+        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
+      );
+
+      expect(storedQuery).toEqual({
+        [objectID1]: [queryID1, expect.any(Number)],
+        [objectID2]: [queryID2, expect.any(Number)]
+      });
+
+      removeQueryForObjects(index, [objectID1, objectID2]);
+
+      const storedQueryAfterRemoval = JSON.parse(
+        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
+      );
+
+      expect(storedQueryAfterRemoval).toEqual({});
     });
   });
 });

--- a/lib/utils/__tests__/objectQueryTracker.test.ts
+++ b/lib/utils/__tests__/objectQueryTracker.test.ts
@@ -4,6 +4,13 @@ import {
   removeQueryForObjects
 } from "../objectQueryTracker";
 
+const wait = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+const stored = () =>
+  JSON.parse(localStorage.getItem("AlgoliaObjectQueryCache")!);
+
 describe("objectQueryTracker", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -17,12 +24,8 @@ describe("objectQueryTracker", () => {
 
       storeQueryForObject(index, objectID, queryID);
 
-      const storedQuery = JSON.parse(
-        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
-      );
-
-      expect(storedQuery).toEqual({
-        [objectID]: [queryID, expect.any(Number)]
+      expect(stored()).toEqual({
+        [`${index}_${objectID}`]: [queryID, expect.any(Number)]
       });
     });
 
@@ -36,14 +39,47 @@ describe("objectQueryTracker", () => {
       storeQueryForObject(index, objectID1, queryID1);
       storeQueryForObject(index, objectID2, queryID2);
 
-      const storedQuery = JSON.parse(
-        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
-      );
-
-      expect(storedQuery).toEqual({
-        [objectID1]: [queryID1, expect.any(Number)],
-        [objectID2]: [queryID2, expect.any(Number)]
+      expect(stored()).toEqual({
+        [`${index}_${objectID1}`]: [queryID1, expect.any(Number)],
+        [`${index}_${objectID2}`]: [queryID2, expect.any(Number)]
       });
+    });
+
+    it("removes the 1000 oldest query when the limit of 5000 is reached", async () => {
+      const index = "myIndex";
+      const oldestObjectID = "123";
+      const newestObjectID = "456";
+      const oldestQueryID = "abc";
+      const newestQueryID = "def";
+
+      storeQueryForObject(index, oldestObjectID, oldestQueryID);
+
+      expect(getQueryForObject(index, oldestObjectID)).toEqual([
+        oldestQueryID,
+        expect.any(Number)
+      ]);
+
+      await wait(1);
+
+      // synthetically generate 5000 entries
+      const store = stored();
+      for (let i = 0; i < 5000; i++) {
+        store[`${index}_object${i}`] = [`query${i}`, Date.now()];
+      }
+      localStorage.setItem("AlgoliaObjectQueryCache", JSON.stringify(store));
+
+      expect(Object.keys(stored())).toHaveLength(5001);
+
+      await wait(1);
+
+      storeQueryForObject(index, newestObjectID, newestQueryID);
+
+      expect(Object.keys(stored())).toHaveLength(4001);
+      expect(getQueryForObject(index, newestObjectID)).toEqual([
+        newestQueryID,
+        expect.any(Number)
+      ]);
+      expect(getQueryForObject(index, oldestObjectID)).toEqual(undefined);
     });
   });
 
@@ -83,22 +119,14 @@ describe("objectQueryTracker", () => {
       storeQueryForObject(index, objectID1, queryID1);
       storeQueryForObject(index, objectID2, queryID2);
 
-      const storedQuery = JSON.parse(
-        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
-      );
-
-      expect(storedQuery).toEqual({
-        [objectID1]: [queryID1, expect.any(Number)],
-        [objectID2]: [queryID2, expect.any(Number)]
+      expect(stored()).toEqual({
+        [`${index}_${objectID1}`]: [queryID1, expect.any(Number)],
+        [`${index}_${objectID2}`]: [queryID2, expect.any(Number)]
       });
 
       removeQueryForObjects(index, [objectID1, objectID2]);
 
-      const storedQueryAfterRemoval = JSON.parse(
-        localStorage.getItem("AlgoliaObjectQueryCache_myIndex")!
-      );
-
-      expect(storedQueryAfterRemoval).toEqual({});
+      expect(stored()).toEqual({});
     });
   });
 });

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -11,6 +11,9 @@ export const isFunction = (value: any): value is Function =>
   typeof value === "function";
 /* eslint-enable */
 
+export const isPromise = <T>(value: Promise<T> | T): value is Promise<T> =>
+  typeof (value as Promise<T> | undefined)?.then === "function";
+
 export * from "./extractAdditionalParams";
 export * from "./featureDetection";
 export * from "./objectQueryTracker";

--- a/lib/utils/localStorage.ts
+++ b/lib/utils/localStorage.ts
@@ -50,17 +50,4 @@ export class LocalStorage {
   static remove(key: string): void {
     localStorage.removeItem(key);
   }
-
-  /**
-   * Check if the storage is nearly full.
-   *
-   * @returns A promise that resolves to a boolean indicating if the storage is > 90% full.
-   */
-  static isNearlyFull(): Promise<boolean> {
-    return navigator.storage.estimate().then(
-      ({ usage, quota }) =>
-        Boolean(usage && quota && usage / quota > LocalStorage.THRESHOLD),
-      () => false
-    );
-  }
 }

--- a/lib/utils/objectQueryTracker.ts
+++ b/lib/utils/objectQueryTracker.ts
@@ -30,3 +30,15 @@ export function getQueryForObject(
 ): [queryId: string, timestamp: number] | undefined {
   return getCache(index)[objectID];
 }
+
+export function removeQueryForObjects(
+  index: string,
+  objectIDs: string[]
+): void {
+  const objectQueryMap = getCache(index);
+
+  objectIDs.forEach((objectID) => {
+    delete objectQueryMap[objectID];
+  });
+  setCache(index, objectQueryMap);
+}

--- a/lib/utils/objectQueryTracker.ts
+++ b/lib/utils/objectQueryTracker.ts
@@ -5,7 +5,7 @@ interface ObjectQueryMap {
 }
 
 const STORE = "AlgoliaObjectQueryCache";
-const LIMIT = 5000; // 1 entry is typically no more than 100 bytes, so this is ~500KB worth of data - most browsers allow at least 5MB per origin
+const LIMIT = 5000; // 1 entry is typically no more than 100 bytes, so this is ~500kB worth of data - most browsers allow at least 5MB per origin
 const FREE = 1000;
 
 function getCache(): ObjectQueryMap {

--- a/lib/utils/objectQueryTracker.ts
+++ b/lib/utils/objectQueryTracker.ts
@@ -1,16 +1,46 @@
 import { LocalStorage } from "./localStorage";
 
 interface ObjectQueryMap {
-  [objectId: string]: [queryId: string, timestamp: number];
+  [indexAndObjectId: string]: [queryId: string, timestamp: number];
 }
 
-const PREFIX = "AlgoliaObjectQueryCache_";
+const STORE = "AlgoliaObjectQueryCache";
+const LIMIT = 5000; // 1 entry is typically no more than 100 bytes, so this is ~500KB worth of data - most browsers allow at least 5MB per origin
+const FREE = 1000;
 
-function getCache(index: string): ObjectQueryMap {
-  return LocalStorage.get(`${PREFIX}${index}`) ?? {};
+function getCache(): ObjectQueryMap {
+  return LocalStorage.get(STORE) ?? {};
 }
-function setCache(index: string, objectQueryMap: ObjectQueryMap): void {
-  LocalStorage.set(`${PREFIX}${index}`, objectQueryMap);
+function setCache(objectQueryMap: ObjectQueryMap): void {
+  LocalStorage.set(STORE, limited(objectQueryMap));
+}
+
+function limited(objectQueryMap: ObjectQueryMap): ObjectQueryMap {
+  return Object.keys(objectQueryMap).length > LIMIT
+    ? purgeOldest(objectQueryMap)
+    : objectQueryMap;
+}
+
+function purgeOldest(objectQueryMap: ObjectQueryMap): ObjectQueryMap {
+  const sorted = Object.entries(objectQueryMap).sort(
+    ([, [, aTimestamp]], [, [, bTimestamp]]) => bTimestamp - aTimestamp
+  );
+
+  const newObjectQueryMap = sorted
+    .slice(0, sorted.length - FREE - 1)
+    .reduce<ObjectQueryMap>(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value
+      }),
+      {}
+    );
+
+  return newObjectQueryMap;
+}
+
+function makeKey(index: string, objectID: string): string {
+  return `${index}_${objectID}`;
 }
 
 export function storeQueryForObject(
@@ -18,27 +48,27 @@ export function storeQueryForObject(
   objectID: string,
   queryID: string
 ): void {
-  const objectQueryMap = getCache(index);
+  const objectQueryMap = getCache();
 
-  objectQueryMap[objectID] = [queryID, Date.now()];
-  setCache(index, objectQueryMap);
+  objectQueryMap[makeKey(index, objectID)] = [queryID, Date.now()];
+  setCache(objectQueryMap);
 }
 
 export function getQueryForObject(
   index: string,
   objectID: string
 ): [queryId: string, timestamp: number] | undefined {
-  return getCache(index)[objectID];
+  return getCache()[makeKey(index, objectID)];
 }
 
 export function removeQueryForObjects(
   index: string,
   objectIDs: string[]
 ): void {
-  const objectQueryMap = getCache(index);
+  const objectQueryMap = getCache();
 
   objectIDs.forEach((objectID) => {
-    delete objectQueryMap[objectID];
+    delete objectQueryMap[makeKey(index, objectID)];
   });
-  setCache(index, objectQueryMap);
+  setCache(objectQueryMap);
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "bundlesize": [
     {
       "path": "./dist/search-insights.min.js",
-      "maxSize": "3.30 kB"
+      "maxSize": "3.60 kB"
     }
   ],
   "packageManager": "yarn@1.22.19"


### PR DESCRIPTION
Added the remaining logic to:
* store any queryID passed for future `purchase` conversion events when `eventSubtype` is `addToCart`
* remove objectID/queryID association from store when `eventSubtype` is `purchase`
* keep most recent 4,000 associations when store reaches 5,000 