### PR TITLE
fix: don't set Content-Length in XMLHttpRequest fn

### DIFF
--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -140,7 +140,11 @@ describe("request", () => {
     expect(sent).toBe(true);
     expect(navigator.sendBeacon).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
-    expect(setRequestHeader).toHaveBeenCalledTimes(2);
+    expect(setRequestHeader).toHaveBeenCalledTimes(1);
+    expect(setRequestHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "application/json"
+    );
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));
@@ -162,7 +166,7 @@ describe("request", () => {
     expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
 
     expect(open).toHaveBeenCalledTimes(1);
-    expect(setRequestHeader).toHaveBeenCalledTimes(2);
+    expect(setRequestHeader).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenLastCalledWith("POST", url);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(JSON.stringify(data));

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -24,7 +24,6 @@ export const requestWithXMLHttpRequest: RequestFnType = (url, data) => {
     req.addEventListener("timeout", () => resolve(false));
     req.open("POST", url);
     req.setRequestHeader("Content-Type", "application/json");
-    req.setRequestHeader("Content-Length", `${serializedData.length}`);
     req.send(serializedData);
   });
 };


### PR DESCRIPTION
Setting the `Content-Length` request header in the context of an XMLHttpRequest leads to the error:
```
Refused to set unsafe header "Content-Length"
```
This header is considered a forbidden request header that can't be set with `setRequestHeader()`. I've confirmed that the initial implementation was unnecessary: https://github.com/algolia/search-insights.js/pull/358#issuecomment-2324026184.

See the XMLHttpRequest specs:
* [setRequestHeader() method](https://xhr.spec.whatwg.org/#the-setrequestheader()-method)
* [Forbidden request header](https://fetch.spec.whatwg.org/#forbidden-request-header)

[CR-6763](https://algolia.atlassian.net/browse/CR-6763)

[CR-6763]: https://algolia.atlassian.net/browse/CR-6763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ