### PR TITLE
fix: save existing anon tokens for multiple init calls 

### DIFF
--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -240,6 +240,23 @@ describe("init", () => {
 
     setUserToken.mockRestore();
   });
+  it("should save anonymous userToken as cookie when useCookie is set to true later", () => {
+    analyticsInstance.init({
+      apiKey: "***",
+      appId: "XXX"
+    });
+
+    analyticsInstance.setUserToken("anonymous-123123123");
+
+    analyticsInstance.init({
+      partial: true,
+      useCookie: true
+    });
+
+    expect(document.cookie).toEqual(
+      expect.stringMatching(/^_ALGOLIA=anonymous-/)
+    );
+  });
   it("should replace existing options when called again", () => {
     analyticsInstance.init({
       apiKey: "apiKey1",

--- a/lib/__tests__/init.test.ts
+++ b/lib/__tests__/init.test.ts
@@ -1,6 +1,7 @@
 import { getCookie, MONTH } from "../_tokenUtils";
 import AlgoliaAnalytics from "../insights";
 import * as utils from "../utils";
+import { createUUID } from "../utils/uuid";
 
 jest.mock("../utils", () => ({
   __esModule: true,
@@ -246,7 +247,7 @@ describe("init", () => {
       appId: "XXX"
     });
 
-    analyticsInstance.setUserToken("anonymous-123123123");
+    analyticsInstance.setUserToken(`anonymous-${createUUID()}`);
 
     analyticsInstance.init({
       partial: true,

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -31,6 +31,24 @@ export const getCookie = (name: string): string => {
   return "";
 };
 
+export function checkIfAnonymousToken(token: number | string): boolean {
+  if (typeof token === "number") {
+    return false;
+  }
+
+  return token.indexOf("anonymous-") === 0;
+}
+
+export function saveTokenAsCookie(this: AlgoliaAnalytics): void {
+  const foundToken = getCookie(COOKIE_KEY);
+  if (
+    this._userToken &&
+    (!foundToken || foundToken === "" || foundToken.indexOf("anonymous-") !== 0)
+  ) {
+    setCookie(COOKIE_KEY, this._userToken, this._cookieDuration);
+  }
+}
+
 export function setAnonymousUserToken(
   this: AlgoliaAnalytics,
   inMemory = false

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -25,7 +25,6 @@ export interface InitParams {
  *
  * @param options - InitParams.
  */
-// eslint-disable-next-line complexity
 export function init(this: AlgoliaAnalytics, options: InitParams = {}): void {
   if (
     !isUndefined(options.region) &&
@@ -81,12 +80,7 @@ You can visit https://algolia.com/events/debugger instead.`);
     this.setUserToken(options.userToken);
   } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
-  } else if (
-    this._userToken &&
-    checkIfAnonymousToken(this._userToken) &&
-    this._useCookie &&
-    !this._userHasOptedOut
-  ) {
+  } else if (checkIfTokenNeedsToBeSaved(this)) {
     this.saveTokenAsCookie();
   }
 }
@@ -116,5 +110,17 @@ function setOptions(
       (acc, key) => ({ ...acc, [`_${key}`]: options[key] }),
       {}
     )
+  );
+}
+
+function checkIfTokenNeedsToBeSaved(target: AlgoliaAnalytics): boolean {
+  if (target._userToken === undefined) {
+    return false;
+  }
+
+  return (
+    checkIfAnonymousToken(target._userToken) &&
+    target._useCookie &&
+    !target._userHasOptedOut
   );
 }

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ALGOLIA_AGENTS } from "./_algoliaAgent";
-import { MONTH } from "./_tokenUtils";
+import { checkIfAnonymousToken, MONTH } from "./_tokenUtils";
 import type AlgoliaAnalytics from "./insights";
 import { isUndefined, isNumber } from "./utils";
 
@@ -25,6 +25,7 @@ export interface InitParams {
  *
  * @param options - InitParams.
  */
+// eslint-disable-next-line complexity
 export function init(this: AlgoliaAnalytics, options: InitParams = {}): void {
   if (
     !isUndefined(options.region) &&
@@ -80,6 +81,13 @@ You can visit https://algolia.com/events/debugger instead.`);
     this.setUserToken(options.userToken);
   } else if (!this._userToken && !this._userHasOptedOut && this._useCookie) {
     this.setAnonymousUserToken();
+  } else if (
+    this._userToken &&
+    checkIfAnonymousToken(this._userToken) &&
+    this._useCookie &&
+    !this._userHasOptedOut
+  ) {
+    this.saveTokenAsCookie();
   }
 }
 

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -11,7 +11,8 @@ import {
   MONTH,
   setAuthenticatedUserToken,
   onAuthenticatedUserTokenChange,
-  getAuthenticatedUserToken
+  getAuthenticatedUserToken,
+  saveTokenAsCookie
 } from "./_tokenUtils";
 import {
   clickedObjectIDsAfterSearch,
@@ -78,6 +79,7 @@ class AlgoliaAnalytics {
   getVersion: typeof getVersion;
   addAlgoliaAgent: typeof addAlgoliaAgent;
 
+  saveTokenAsCookie: typeof saveTokenAsCookie;
   setUserToken: typeof setUserToken;
   setAnonymousUserToken: typeof setAnonymousUserToken;
   getUserToken: typeof getUserToken;
@@ -110,6 +112,7 @@ class AlgoliaAnalytics {
 
     this.addAlgoliaAgent = addAlgoliaAgent.bind(this);
 
+    this.saveTokenAsCookie = saveTokenAsCookie.bind(this);
     this.setUserToken = setUserToken.bind(this);
     this.setAnonymousUserToken = setAnonymousUserToken.bind(this);
     this.getUserToken = getUserToken.bind(this);


### PR DESCRIPTION
### Context

In InstantSearch, in order for user tokens to be set in time for the first query on page load, anonymous user tokens are generated and set as both the InstantSearch token and Insights token.

This flow has one issue though. When `useCookies` flag needs to be changed later (such as with a cookie consent banner), a second `init` call to insights with the flag set to true does not save the existing token to a cookie.

A short repro is as follows with the very latest version of InstantSearch where this behaviour was added (PR: https://github.com/algolia/instantsearch/pull/6377):

```js
const searchClient = algoliasearch(
  // ...
);

window.aa('init', {
  appId: 'id',
  apiKey: 'key',
});

const search = instantsearch({
  indexName: 'index',
  searchClient,
  insights: true,
});

search.addWidgets([
  // ...
]);

// This does not save the cookie atm
setTimeout(() => {
  window.aa('init', {
    partial: true,
    useCookie: true,
  });
}, 5000);
```