### PR TITLE
cleanup: remove unnecessary console.log in dev

### DIFF
--- a/lib/init.ts
+++ b/lib/init.ts
@@ -47,11 +47,6 @@ export function init(this: AlgoliaAnalytics, options: InitParams = {}): void {
     );
   }
 
-  /* eslint-disable no-console */
-  if (__DEV__) {
-    console.info(`Since v2.0.4, search-insights no longer validates event payloads.
-You can visit https://algolia.com/events/debugger instead.`);
-  }
   /* eslint-enable */
 
   setOptions(this, options, {

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -47,8 +47,6 @@ export function init(this: AlgoliaAnalytics, options: InitParams = {}): void {
     );
   }
 
-  /* eslint-enable */
-
   setOptions(this, options, {
     _userHasOptedOut: Boolean(options.userHasOptedOut),
     _region: options.region,


### PR DESCRIPTION
Remove unnecessary `console.log` message from `algolia/search-insights`, which stated:
"Since v2.0.4, search-insights no longer validates event payloads."
This message appeared in dev mode and is no longer needed (as it's over 2 years old by now)