### PR TITLE
feat: add Secure flag to _ALGOLIA cookie on HTTPS sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Search Insights lets you report click, conversion and view metrics using the [Al
 
 v2 introduces a breaking change which is `useCookie` being `false` by default.
 
-The `_ALGOLIA` cookie automatically includes the `Secure` flag when used on HTTPS sites for enhanced security.
+The `_ALGOLIA` cookie automatically includes the `Secure` flag on HTTPS sites, ensuring it's only sent over encrypted connections.
 
 ### Payload validation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Search Insights lets you report click, conversion and view metrics using the [Al
 
 v2 introduces a breaking change which is `useCookie` being `false` by default.
 
+The `_ALGOLIA` cookie automatically includes the `Secure` flag when used on HTTPS sites for enhanced security.
+
 ### Payload validation
 
 Since v2.0.4, search-insights no longer validates event payloads.

--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -162,7 +162,8 @@ describe("tokenUtils", () => {
       // Clear all cookies before each test
       document.cookie.split(";").forEach((cookie) => {
         const eqPos = cookie.indexOf("=");
-        const name = eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim();
+        const name =
+          eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim();
         document.cookie = `${name}=;expires=Thu, 01-Jan-1970 00:00:01 GMT;path=/`;
       });
 

--- a/lib/__tests__/_tokenUtils.test.ts
+++ b/lib/__tests__/_tokenUtils.test.ts
@@ -153,4 +153,148 @@ describe("tokenUtils", () => {
       );
     });
   });
+
+  describe("cookie security flags", () => {
+    const originalLocation = window.location;
+    let cookieSetter: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Clear all cookies before each test
+      document.cookie.split(";").forEach((cookie) => {
+        const eqPos = cookie.indexOf("=");
+        const name = eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim();
+        document.cookie = `${name}=;expires=Thu, 01-Jan-1970 00:00:01 GMT;path=/`;
+      });
+
+      cookieSetter = jest.spyOn(
+        Object.getPrototypeOf(document),
+        "cookie",
+        "set"
+      );
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: originalLocation
+      });
+
+      cookieSetter.mockRestore();
+    });
+
+    describe("on HTTPS", () => {
+      beforeEach(() => {
+        // HTTPS mock
+        delete (window as any).location;
+        window.location = { ...originalLocation, protocol: "https:" } as any;
+      });
+
+      it("should set Secure flag when creating anonymous token on HTTPS", () => {
+        analyticsInstance.setAnonymousUserToken();
+
+        expect(cookieSetter).toHaveBeenCalled();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+
+        expect(cookieString).toContain("_ALGOLIA=anonymous-mock-uuid-1");
+        expect(cookieString).toContain(";Secure");
+        expect(cookieString).toContain("expires=");
+        expect(cookieString).toContain("path=/");
+      });
+
+      it("should set all cookie attributes on HTTPS", () => {
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+
+        expect(cookieString).toContain(";Secure");
+        expect(cookieString).toContain("_ALGOLIA=anonymous-mock-uuid-1");
+        expect(cookieString).toContain("expires=");
+        expect(cookieString).toContain("path=/");
+      });
+    });
+
+    describe("on HTTP", () => {
+      beforeEach(() => {
+        // HTTP mock
+        delete (window as any).location;
+        window.location = { ...originalLocation, protocol: "http:" } as any;
+      });
+
+      it("should NOT set Secure flag when creating anonymous token on HTTP", () => {
+        analyticsInstance.setAnonymousUserToken();
+
+        expect(cookieSetter).toHaveBeenCalled();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+
+        expect(cookieString).toContain("_ALGOLIA=anonymous-mock-uuid-1");
+        expect(cookieString).not.toContain(";Secure");
+        expect(cookieString).not.toContain("Secure");
+      });
+
+      it("should still set basic cookie attributes on HTTP", () => {
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+
+        expect(cookieString).toContain("_ALGOLIA=anonymous-mock-uuid-1");
+        expect(cookieString).toContain("expires=");
+        expect(cookieString).toContain("path=/");
+
+        expect(document.cookie).toContain("_ALGOLIA=anonymous-mock-uuid-1");
+      });
+    });
+
+    describe("protocol detection", () => {
+      it("should correctly detect HTTPS protocol", () => {
+        delete (window as any).location;
+        window.location = { ...originalLocation, protocol: "https:" } as any;
+
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+        expect(cookieString).toContain(";Secure");
+      });
+
+      it("should correctly detect HTTP protocol", () => {
+        delete (window as any).location;
+        window.location = { ...originalLocation, protocol: "http:" } as any;
+
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+        expect(cookieString).not.toContain(";Secure");
+      });
+
+      it("should handle localhost with HTTPS", () => {
+        delete (window as any).location;
+        window.location = {
+          ...originalLocation,
+          protocol: "https:",
+          hostname: "localhost"
+        } as any;
+
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+        expect(cookieString).toContain(";Secure");
+      });
+
+      it("should handle localhost with HTTP", () => {
+        delete (window as any).location;
+        window.location = {
+          ...originalLocation,
+          protocol: "http:",
+          hostname: "localhost"
+        } as any;
+
+        analyticsInstance.setAnonymousUserToken();
+
+        const cookieString = cookieSetter.mock.calls[0][0];
+        expect(cookieString).not.toContain(";Secure");
+      });
+    });
+  });
 });

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -13,8 +13,8 @@ const setCookie = (
   const d = new Date();
   d.setTime(d.getTime() + duration);
   const expires = `expires=${d.toUTCString()}`;
-  const isSecure = location.protocol === 'https:';
-  const secureFlag = isSecure ? ';Secure' : '';
+  const isSecure = location.protocol === "https:";
+  const secureFlag = isSecure ? ";Secure" : "";
   document.cookie = `${name}=${value};${expires};path=/${secureFlag}`;
 };
 

--- a/lib/_tokenUtils.ts
+++ b/lib/_tokenUtils.ts
@@ -13,7 +13,9 @@ const setCookie = (
   const d = new Date();
   d.setTime(d.getTime() + duration);
   const expires = `expires=${d.toUTCString()}`;
-  document.cookie = `${name}=${value};${expires};path=/`;
+  const isSecure = location.protocol === 'https:';
+  const secureFlag = isSecure ? ';Secure' : '';
+  document.cookie = `${name}=${value};${expires};path=/${secureFlag}`;
 };
 
 export const getCookie = (name: string): string => {


### PR DESCRIPTION
 ## Summary
  Adds the `Secure` flag to the `_ALGOLIA` cookie when used on HTTPS sites to address security audit findings.
  
  [JIRA Ticket](https://algolia.atlassian.net/browse/EEX-1324)